### PR TITLE
chore: add sample PRs to contribution guidlines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -105,6 +105,13 @@ Please take these general guidelines into consideration when you are sending a P
 
 When you are ready to send a PR, we recommend you to first open a `draft` one. This will trigger a bunch of `tests` [workflows](https://github.com/instill-ai/component/tree/main/.github/workflows) running a thorough test suite on multiple platforms. After the tests are done and passed, you can now mark the PR `open` to notify the codebase owners to review. We appreciate your endeavour to pass the integration test for your PR to make sure the sanity with respect to the entire scope of **Instill Core**.
 
+Refer some of these PRs for a quick sample -  
+https://github.com/instill-ai/operator/pull/7  
+https://github.com/instill-ai/operator/pull/8  
+https://github.com/instill-ai/connector-data/pull/12  
+https://github.com/instill-ai/connector-ai/pull/22 (this one is a bit old, the interface is changed now)
+
+
 ## Last words
 
 Your contributions make a difference. Let's build something amazing together!


### PR DESCRIPTION
Because

- current contribution guidelines don't have any sample PRs

This commit

- adds a few sample PRs for reference
