### PR TITLE
chore(jsonschema): support `instillUpstreamType`: `template`

### DIFF
--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -112,7 +112,9 @@ func (c *Connector) ListConnectorDefinitions() []*connectorPB.ConnectorDefinitio
 	compDefs := c.Component.listDefinitions()
 	defs := []*connectorPB.ConnectorDefinition{}
 	for _, compDef := range compDefs {
-		defs = append(defs, compDef.(*connectorPB.ConnectorDefinition))
+		if !compDef.(*connectorPB.ConnectorDefinition).Tombstone {
+			defs = append(defs, compDef.(*connectorPB.ConnectorDefinition))
+		}
 	}
 	return defs
 }

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -95,7 +95,9 @@ func (o *Operator) ListOperatorDefinitions() []*pipelinePB.OperatorDefinition {
 	compDefs := o.Component.listDefinitions()
 	defs := []*pipelinePB.OperatorDefinition{}
 	for _, compDef := range compDefs {
-		defs = append(defs, compDef.(*pipelinePB.OperatorDefinition))
+		if !compDef.(*pipelinePB.OperatorDefinition).Tombstone {
+			defs = append(defs, compDef.(*pipelinePB.OperatorDefinition))
+		}
 	}
 	return defs
 }


### PR DESCRIPTION
Because

- we need to mark which fields allow using template

This commit

- support `instillUpstreamType`: `template`
- support `instillUpstreamType` for `patternProperties`