### PR TITLE
ci(workflow): update github action default token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,10 +6,13 @@ jobs:
   codecov:
     name: codecov
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.botGitHubToken }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2


### PR DESCRIPTION
Because

- we need to update github action default token

This commit

- update github action default token
