### PR TITLE
refactor(component): refactor instillFormat xxx_array to array

### DIFF
--- a/shared_schema.json
+++ b/shared_schema.json
@@ -96,7 +96,7 @@
             "title": "Objects",
             "description": "A list of detected objects.",
             "type": "array",
-            "instillFormat": "object_array",
+            "instillFormat": "array",
             "instillUIOrder": 0,
             "items": {
               "type": "object",
@@ -139,7 +139,7 @@
             "title": "Objects",
             "description": "A list of keypoint objects, a keypoint object includes all the pre-defined keypoints of a detected object.",
             "type": "array",
-            "instillFormat": "object_array",
+            "instillFormat": "array",
             "instillUIOrder": 0,
             "items": {
               "type": "object",
@@ -150,7 +150,7 @@
                 "keypoints": {
                   "title": "Keypoints",
                   "description": "A keypoint group is composed of a list of pre-defined keypoints of a detected object.",
-                  "type": "object_array",
+                  "type": "array",
                   "instillUIOrder": 0,
                   "items": {
                     "type": "object",
@@ -207,7 +207,7 @@
             "title": "Objects",
             "description": "A list of detected bounding boxes.",
             "type": "array",
-            "instillFormat": "object_array",
+            "instillFormat": "array",
             "instillUIOrder": 0,
             "items": {
               "type": "object",
@@ -249,7 +249,7 @@
             "title": "Objects",
             "description": "A list of detected instance bounding boxes.",
             "type": "array",
-            "instillFormat": "object_array",
+            "instillFormat": "array",
             "instillUIOrder": 0,
             "items": {
               "type": "object",
@@ -298,7 +298,7 @@
             "title": "Stuffs",
             "description": "A list of RLE binary masks.",
             "type": "array",
-            "instillFormat": "object_array",
+            "instillFormat": "array",
             "instillUIOrder": 0,
             "items": {
               "type": "object",
@@ -328,7 +328,7 @@
       "embedding": {
         "title": "Embedding",
         "type": "array",
-        "instillFormat": "number_array",
+        "instillFormat": "array",
         "items": {
           "title": "Embedding",
           "type": "number",


### PR DESCRIPTION
Because

- we should use `instillFormat: array` to simplify the json-schema structure

This commit

- refactor `instillFormat: xxx_array` to `array`
