### PR TITLE
refactor(component): add json-schema validator for `instillAcceptFormats` and `instillFormat`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/instill-ai/component
 go 1.21
 
 require (
+	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
+github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=

--- a/pkg/base/execution.go
+++ b/pkg/base/execution.go
@@ -3,6 +3,8 @@ package base
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/santhosh-tekuri/jsonschema/v5"
@@ -15,7 +17,7 @@ import (
 type IExecution interface {
 	// Functions that shared for all connectors
 	// Validate the input and output format
-	Validate(data []*structpb.Struct, jsonSchema string) error
+	Validate(data []*structpb.Struct, jsonSchema string, target string) error
 
 	// Execute
 	GetTask() string
@@ -53,27 +55,68 @@ func (e *Execution) GetConfig() *structpb.Struct {
 	return e.Config
 }
 
+func FormatErrors(inputPath string, e jsonschema.Detailed, errors *[]string) {
+
+	path := inputPath + e.InstanceLocation
+
+	pathItems := strings.Split(path, "/")
+	formatedPath := pathItems[0]
+	for _, pathItem := range pathItems[1:] {
+		if _, err := strconv.Atoi(pathItem); err == nil {
+			formatedPath += fmt.Sprintf("[%s]", pathItem)
+		} else {
+			formatedPath += fmt.Sprintf(".%s", pathItem)
+		}
+
+	}
+	*errors = append(*errors, fmt.Sprintf("%s: %s", formatedPath, e.Error))
+
+}
+
 // Validate the input and output format
-func (e *Execution) Validate(data []*structpb.Struct, jsonSchema string) error {
-	sch, err := jsonschema.CompileString("schema.json", jsonSchema)
+func (e *Execution) Validate(data []*structpb.Struct, jsonSchema string, target string) error {
+	c := jsonschema.NewCompiler()
+	c.RegisterExtension("instillAcceptFormats", InstillAcceptFormatsMeta, InstillAcceptFormatsCompiler{})
+	c.RegisterExtension("instillFormat", InstillFormatMeta, InstillFormatCompiler{})
+	if err := c.AddResource("schema.json", strings.NewReader(jsonSchema)); err != nil {
+		return err
+	}
+	sch, err := c.Compile("schema.json")
 	if err != nil {
 		return err
 	}
+	errors := []string{}
+
 	for idx := range data {
 		var v interface{}
 		jsonData, err := protojson.Marshal(data[idx])
 		if err != nil {
-			return err
+			errors = append(errors, fmt.Sprintf("%s[%d]: data error", target, idx))
+			continue
 		}
 
 		if err := json.Unmarshal(jsonData, &v); err != nil {
-			return err
+			errors = append(errors, fmt.Sprintf("%s[%d]: data error", target, idx))
+			continue
 		}
 
 		if err = sch.Validate(v); err != nil {
-			return err
+			e := err.(*jsonschema.ValidationError)
+
+			for _, valErr := range e.DetailedOutput().Errors {
+				inputPath := fmt.Sprintf("%s/%d", target, idx)
+				FormatErrors(inputPath, valErr, &errors)
+				for _, subValErr := range valErr.Errors {
+					FormatErrors(inputPath, subValErr, &errors)
+				}
+			}
 		}
 	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("%s", strings.Join(errors, "; "))
+	}
+
 	return nil
 }
 
@@ -95,7 +138,7 @@ func (e *Execution) ExecuteWithValidation(inputs []*structpb.Struct) ([]*structp
 		return nil, fmt.Errorf("no task %s", e.GetTask())
 	}
 
-	if err := e.Validate(inputs, e.Component.GetTaskInputSchemas()[task]); err != nil {
+	if err := e.Validate(inputs, e.Component.GetTaskInputSchemas()[task], "inputs"); err != nil {
 		return nil, err
 	}
 
@@ -104,7 +147,7 @@ func (e *Execution) ExecuteWithValidation(inputs []*structpb.Struct) ([]*structp
 		return nil, err
 	}
 
-	if err := e.Validate(outputs, e.Component.GetTaskOutputSchemas()[task]); err != nil {
+	if err := e.Validate(outputs, e.Component.GetTaskOutputSchemas()[task], "outputs"); err != nil {
 		return nil, err
 	}
 	return outputs, err

--- a/pkg/base/formats.go
+++ b/pkg/base/formats.go
@@ -1,0 +1,154 @@
+package base
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/gabriel-vasile/mimetype"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type InstillAcceptFormatsCompiler struct{}
+
+func (InstillAcceptFormatsCompiler) Compile(ctx jsonschema.CompilerContext, m map[string]interface{}) (jsonschema.ExtSchema, error) {
+	if instillAcceptFormats, ok := m["instillAcceptFormats"]; ok {
+
+		formats := []string{}
+		for _, instillAcceptFormat := range instillAcceptFormats.([]interface{}) {
+			formats = append(formats, instillAcceptFormat.(string))
+		}
+		return InstillAcceptFormatsSchema(formats), nil
+	}
+
+	return nil, nil
+}
+
+type InstillAcceptFormatsSchema []string
+
+func (s InstillAcceptFormatsSchema) Validate(ctx jsonschema.ValidationContext, v interface{}) error {
+
+	switch v := v.(type) {
+
+	case string:
+		for _, instillAcceptFormat := range s {
+
+			switch instillAcceptFormat {
+			case "string", "*", "*/*":
+				return nil
+			default:
+
+				b, err := base64.StdEncoding.DecodeString(v)
+				if err != nil {
+					return ctx.Error("instillAcceptFormats", "can not decode file")
+				}
+
+				mimeType := strings.Split(mimetype.Detect(b).String(), ";")[0]
+				if strings.Split(mimeType, "/")[0] == strings.Split(instillAcceptFormat, "/")[0] && strings.Split(instillAcceptFormat, "/")[1] == "*" {
+					return nil
+				} else if mimeType == instillAcceptFormat {
+					return nil
+				} else {
+					return ctx.Error("instillAcceptFormats", "expected one of %v, but got %s", s, mimeType)
+				}
+
+			}
+
+		}
+		return nil
+
+	default:
+		return nil
+	}
+}
+
+var InstillAcceptFormatsMeta = jsonschema.MustCompileString("instillAcceptFormats.json", `{
+	"properties" : {
+		"instillAcceptFormats": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		}
+	}
+}`)
+
+type InstillFormatCompiler struct{}
+
+func (InstillFormatCompiler) Compile(ctx jsonschema.CompilerContext, m map[string]interface{}) (jsonschema.ExtSchema, error) {
+	if _, ok := m["instillFormat"]; ok {
+
+		return InstillFormatSchema(m["instillFormat"].(string)), nil
+	}
+
+	return nil, nil
+}
+
+type InstillFormatSchema string
+
+func (s InstillFormatSchema) Validate(ctx jsonschema.ValidationContext, v interface{}) error {
+
+	switch v := v.(type) {
+
+	case string:
+
+		switch string(s) {
+		case "string", "*", "*/*":
+			return nil
+		default:
+			b, err := base64.StdEncoding.DecodeString(v)
+			if err != nil {
+				return ctx.Error("instillFormat", "can not decode file")
+			}
+
+			mimeType := strings.Split(mimetype.Detect(b).String(), ";")[0]
+			if strings.Split(mimeType, "/")[0] == strings.Split(string(s), "/")[0] && strings.Split(string(s), "/")[1] == "*" {
+				return nil
+			} else if mimeType == string(s) {
+				return nil
+			} else {
+				return ctx.Error("instillFormat", "expected %v, but got %s", s, mimeType)
+			}
+
+		}
+
+	default:
+		return nil
+	}
+}
+
+var InstillFormatMeta = jsonschema.MustCompileString("instillFormat.json", `{
+	"properties" : {
+		"instillFormat": {
+			"type": "string"
+		}
+	}
+}`)
+
+func CompileInstillAcceptFormats(sch *structpb.Struct) error {
+	var err error
+	for k, v := range sch.Fields {
+		if v.GetStructValue() != nil {
+			err = CompileInstillAcceptFormats(v.GetStructValue())
+			if err != nil {
+				return err
+			}
+		}
+		if k == "instillAcceptFormats" {
+			itemInstillAcceptFormats := []interface{}{}
+			for _, item := range v.GetListValue().AsSlice() {
+				if strings.HasPrefix(item.(string), "array:") {
+					itemInstillAcceptFormats = append(itemInstillAcceptFormats, strings.Split(item.(string), ":")[1])
+				}
+			}
+			if len(itemInstillAcceptFormats) > 0 {
+				sch.Fields["items"].GetStructValue().Fields["instillAcceptFormats"], err = structpb.NewValue(itemInstillAcceptFormats)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+	}
+	return nil
+}


### PR DESCRIPTION
Because

- besides the original json-schema, we also need to validate the `instillAcceptFormats` and `instillFormat` for component input and output

This commit

- add json-schema validator for `instillAcceptFormats` and `instillFormat`
