### PR TITLE
chore(component): fix OpenAPI schema bug

### DIFF
--- a/pkg/base/component.go
+++ b/pkg/base/component.go
@@ -343,6 +343,7 @@ func convertDataSpecToOpenAPISpec(dataSpec *structpb.Struct) (*structpb.Struct, 
 
 		newCompSpec := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
 
+		newCompSpec.Fields["type"] = structpb.NewStringValue(compSpec.Fields["type"].GetStringValue())
 		newCompSpec.Fields["title"] = structpb.NewStringValue(compSpec.Fields["title"].GetStringValue())
 		newCompSpec.Fields["description"] = structpb.NewStringValue(compSpec.Fields["description"].GetStringValue())
 		if _, ok := newCompSpec.Fields["instillShortDescription"]; ok {


### PR DESCRIPTION
Because

- the `type` is missing in component OpenAPI schema

This commit

- fix OpenAPI schema bug
