### PR TITLE
chore(deps): upgrade protobufs version to beta

### DIFF
--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 // IConnector is the interface that all connectors need to implement

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gofrs/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 // IOperator is the interface that all operators need to implement


### PR DESCRIPTION
Because

- we are going to release beta version of Core and VDP

This commit

- upgrade protobufs version to beta
