### PR TITLE
feat: add `instillUpstreamTypes: template` in component condition field

### DIFF
--- a/pkg/base/component.go
+++ b/pkg/base/component.go
@@ -19,7 +19,7 @@ const conditionJson = `
 	"instillUIOrder": 1,
 	"instillShortDescription": "config whether the component will be executed or skipped",
 	"instillAcceptFormats": ["string"],
-    "instillUpstreamTypes": ["value"]
+    "instillUpstreamTypes": ["value", "template"]
 }
 `
 


### PR DESCRIPTION
Because

- We need to make the smart hint works for `condition` field on Console, so we need to update the `instillUpstreamTypes`.

This commit

- add `instillUpstreamTypes: template` in component condition field
