### PR TITLE
feat: update GetOperatorDefinition functions to support dynamic definition

### DIFF
--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -27,9 +27,9 @@ type IConnector interface {
 	// Add definition
 	AddConnectorDefinition(def *pipelinePB.ConnectorDefinition) error
 	// Get the connector definition by definition uid
-	GetConnectorDefinitionByUID(defUID uuid.UUID) (*pipelinePB.ConnectorDefinition, error)
+	GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error)
 	// Get the connector definition by definition id
-	GetConnectorDefinitionByID(defID string) (*pipelinePB.ConnectorDefinition, error)
+	GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error)
 	// Get the list of connector definitions under this connector
 	ListConnectorDefinitions() []*pipelinePB.ConnectorDefinition
 
@@ -184,7 +184,7 @@ func (c *Connector) ListConnectorDefinitions() []*pipelinePB.ConnectorDefinition
 }
 
 // GetConnectorDefinitionByUID gets the connector definition by definition uid
-func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID) (*pipelinePB.ConnectorDefinition, error) {
+func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
 	def, err := c.Component.getDefinitionByUID(defUID)
 	if err != nil {
 		return nil, err
@@ -193,7 +193,7 @@ func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID) (*pipelinePB.C
 }
 
 // GetConnectorDefinitionByID gets the connector definition by definition id
-func (c *Connector) GetConnectorDefinitionByID(defID string) (*pipelinePB.ConnectorDefinition, error) {
+func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
 	def, err := c.Component.getDefinitionByID(defID)
 	if err != nil {
 		return nil, err

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
@@ -20,9 +21,9 @@ type IOperator interface {
 	// Add definition
 	AddOperatorDefinition(def *pipelinePB.OperatorDefinition) error
 	// Get the operator definition by definition uid
-	GetOperatorDefinitionByUID(defUID uuid.UUID) (*pipelinePB.OperatorDefinition, error)
+	GetOperatorDefinitionByUID(defUID uuid.UUID, componentConfig *structpb.Struct) (*pipelinePB.OperatorDefinition, error)
 	// Get the operator definition by definition id
-	GetOperatorDefinitionByID(defID string) (*pipelinePB.OperatorDefinition, error)
+	GetOperatorDefinitionByID(defID string, componentConfig *structpb.Struct) (*pipelinePB.OperatorDefinition, error)
 	// Get the list of operator definitions under this operator
 	ListOperatorDefinitions() []*pipelinePB.OperatorDefinition
 }
@@ -108,7 +109,7 @@ func (o *Operator) ListOperatorDefinitions() []*pipelinePB.OperatorDefinition {
 }
 
 // GetOperatorDefinitionByUID returns the operator definition by definition uid
-func (o *Operator) GetOperatorDefinitionByUID(defUID uuid.UUID) (*pipelinePB.OperatorDefinition, error) {
+func (o *Operator) GetOperatorDefinitionByUID(defUID uuid.UUID, componentConfig *structpb.Struct) (*pipelinePB.OperatorDefinition, error) {
 	def, err := o.Component.getDefinitionByUID(defUID)
 	if err != nil {
 		return nil, err
@@ -117,7 +118,7 @@ func (o *Operator) GetOperatorDefinitionByUID(defUID uuid.UUID) (*pipelinePB.Ope
 }
 
 // GetOperatorDefinitionByID returns the operator definition by definition id
-func (o *Operator) GetOperatorDefinitionByID(defID string) (*pipelinePB.OperatorDefinition, error) {
+func (o *Operator) GetOperatorDefinitionByID(defID string, componentConfig *structpb.Struct) (*pipelinePB.OperatorDefinition, error) {
 	def, err := o.Component.getDefinitionByID(defID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Because

Originally, our connector definitions are fixed. However, in some scenarios, the definition will be dynamic.

The component JSON schema can be influenced by connector configuration. For example, the Instill Model Connector can retrieve the model list and incorporate it into the component JSON schema as an enumeration.

The OpenAPI schema can be influenced by both connector and component configuration. For example, we can let user define the JSON schema of the output body in the RestAPI connector and utilize it to generate the OpenAPI schema of the RestAPI connector.

Therefore, we would like to make these connector definitions dynamically generated.

This commit

- update GetOperatorDefinition functions to support dynamic definition
