### PR TITLE
feat: extract task title generation

### DIFF
--- a/pkg/base/component.go
+++ b/pkg/base/component.go
@@ -214,6 +214,16 @@ func convertDataSpecToCompSpec(dataSpec *structpb.Struct) (*structpb.Struct, err
 	return compSpec, nil
 }
 
+const taskPrefix = "TASK_"
+
+// TaskIDToTitle builds a Task title from its ID. This is used when the `title`
+// key in the task definition isn't present.
+func TaskIDToTitle(id string) string {
+	title := strings.ReplaceAll(id, taskPrefix, "")
+	title = strings.ReplaceAll(title, "_", " ")
+	return cases.Title(language.English).String(title)
+}
+
 func (comp *Component) generateComponentTasks(availableTasks []string) []*pipelinePB.ComponentTask {
 	tasks := make([]*pipelinePB.ComponentTask, 0, len(availableTasks))
 	for _, t := range availableTasks {


### PR DESCRIPTION
Because

- INS-3584 (README auto-gen) needs to build the task title in case it isn't
  defined in the task schema.

This commit

- Extracts the already implemented code for task titles to a public method.
