### PR TITLE
feat: expose description field in component entities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/frankban/quicktest v1.14.6
 	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240226101151-03ed57d8f5f7
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c
 	github.com/lestrrat-go/jsref v0.0.0-20211028120858-c0bcbb5abf20
 	github.com/lestrrat-go/option v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240226101151-03ed57d8f5f7 h1:h8u5tmkmoHaJy6CpRNZtFLac5x6AGa9PWt2cfK7kH2Y=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240226101151-03ed57d8f5f7/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e h1:fHbGDWVbaFFSrqRmy5cKDlBT/8nlsfS5m5LIo3P7Q70=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -176,13 +176,15 @@ func (c *Connector) AddConnectorDefinition(def *pipelinePB.ConnectorDefinition) 
 // ListConnectorDefinitions lists all the connector definitions
 func (c *Connector) ListConnectorDefinitions() []*pipelinePB.ConnectorDefinition {
 	compDefs := c.Component.listDefinitions()
-	defs := []*pipelinePB.ConnectorDefinition{}
-	for _, compDef := range compDefs {
-		if !compDef.(*pipelinePB.ConnectorDefinition).Tombstone {
-			defs = append(defs, compDef.(*pipelinePB.ConnectorDefinition))
+	connDefs := make([]*pipelinePB.ConnectorDefinition, 0, len(compDefs))
+	for _, d := range compDefs {
+		cd := d.(*pipelinePB.ConnectorDefinition)
+		if !cd.Tombstone {
+			connDefs = append(connDefs, cd)
 		}
 	}
-	return defs
+
+	return connDefs
 }
 
 // GetConnectorDefinitionByUID gets the connector definition by definition uid

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -101,13 +101,15 @@ func (o *Operator) AddOperatorDefinition(def *pipelinePB.OperatorDefinition) err
 // ListOperatorDefinitions returns the list of operator definitions under this operator
 func (o *Operator) ListOperatorDefinitions() []*pipelinePB.OperatorDefinition {
 	compDefs := o.Component.listDefinitions()
-	defs := []*pipelinePB.OperatorDefinition{}
-	for _, compDef := range compDefs {
-		if !compDef.(*pipelinePB.OperatorDefinition).Tombstone {
-			defs = append(defs, compDef.(*pipelinePB.OperatorDefinition))
+	opDefs := make([]*pipelinePB.OperatorDefinition, 0, len(compDefs))
+	for _, d := range compDefs {
+		od := d.(*pipelinePB.OperatorDefinition)
+		if !od.Tombstone {
+			opDefs = append(opDefs, od)
 		}
 	}
-	return defs
+
+	return opDefs
 }
 
 // GetOperatorDefinitionByUID returns the operator definition by definition uid

--- a/tools/compogen/README.md
+++ b/tools/compogen/README.md
@@ -34,7 +34,7 @@ following fields must be present and comply with the following guidelines:
 - `title`.
 - `description` - It should contain a single sentence describing the component.
   The template will use it next to the component title (`{{ .Title }}{{
-  .Description }}.`) so it must be written in third person, present tense.
+  .Description }}.`) so it must be written in imperative tense.
 - `version` - Must be valid SemVer 2.0.0.
 - `type` - Connector definitions must contain this field and its value must
   match one of the (string) values defined in [protobufs](https://github.com/instill-ai/protobufs/blob/main/vdp/pipeline/v1beta/connector_definition.proto).

--- a/tools/compogen/go.mod
+++ b/tools/compogen/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/frankban/quicktest v1.14.6
 	github.com/go-playground/validator/v10 v10.18.0
 	github.com/instill-ai/component v0.11.0-beta.0.20240222072616-52804d408e44
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240226101151-03ed57d8f5f7
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e
 	github.com/launchdarkly/go-semver v1.0.2
 	github.com/rogpeppe/go-internal v1.12.0
 	github.com/russross/blackfriday/v2 v2.1.0

--- a/tools/compogen/go.sum
+++ b/tools/compogen/go.sum
@@ -35,8 +35,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/instill-ai/component v0.11.0-beta.0.20240222072616-52804d408e44 h1:tcRZVBTROfWRH+E33KhoK8mn6pS5oHtXEQqpXzI5cnI=
 github.com/instill-ai/component v0.11.0-beta.0.20240222072616-52804d408e44/go.mod h1:THyROt2dqqge2lDc+PVzm/+LueG4dBtxpLzSjl+T83A=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240226101151-03ed57d8f5f7 h1:h8u5tmkmoHaJy6CpRNZtFLac5x6AGa9PWt2cfK7kH2Y=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240226101151-03ed57d8f5f7/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e h1:fHbGDWVbaFFSrqRmy5cKDlBT/8nlsfS5m5LIo3P7Q70=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/tools/compogen/pkg/gen/resources/templates/readme.mdx.tmpl
+++ b/tools/compogen/pkg/gen/resources/templates/readme.mdx.tmpl
@@ -5,7 +5,7 @@ draft: {{ .IsDraft }}
 description: "Learn about how to set up a VDP {{ .Title }} {{ .ComponentType }} https://github.com/instill-ai/vdp"
 ---
 
-The {{ .Title }} component is {{ .ComponentSubtype.IndefiniteArticle }} {{ .ComponentSubtype }} that {{ firstToLower .Description }}.
+The {{ .Title }} component is {{ .ComponentSubtype.IndefiniteArticle }} {{ .ComponentSubtype }} that allows users to {{ firstToLower .Description }}.
 It can carry out the following tasks:
 {{ range .Tasks }}
 - [{{ .Title }}](#{{ asAnchor .Title}}){{ end }}


### PR DESCRIPTION
Because

- Component page includes a short description of the component.
- `operator` and `connector` descriptions were added / updated to use the imperative tense

This commit

- Includes the latest version of `protogen-go`, which exposes the `description` field. This will be automatically loaded from `definitions.json`
- Adds a minor optimization that sets the capacity component list slices, avoiding potential reallocations as the list grows.
- Updates the `compogen readme` template to use the descriptions in imperative tense.
