### PR TITLE
fix(vdp): better casting errors

### DIFF
--- a/pkg/base/component.go
+++ b/pkg/base/component.go
@@ -550,7 +550,7 @@ func (comp *Component) listDefinitions() []interface{} {
 func (comp *Component) getDefinitionByUID(defUID uuid.UUID) (interface{}, error) {
 	val, ok := comp.definitionMapByUID[defUID]
 	if !ok {
-		return nil, fmt.Errorf("get connector/operator definition error")
+		return nil, fmt.Errorf("component definition UID doesn't exist")
 	}
 	return val, nil
 }
@@ -559,7 +559,7 @@ func (comp *Component) getDefinitionByID(defID string) (interface{}, error) {
 
 	val, ok := comp.definitionMapByID[defID]
 	if !ok {
-		return nil, fmt.Errorf("get connector/operator definition error")
+		return nil, fmt.Errorf("component definition ID doesn't exist")
 	}
 	return val, nil
 }

--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -188,12 +188,18 @@ func (c *Connector) ListConnectorDefinitions() []*pipelinePB.ConnectorDefinition
 }
 
 // GetConnectorDefinitionByUID gets the connector definition by definition uid
-func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
+func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, _ /*resourceConfig*/ *structpb.Struct, _ /* componentConfig */ *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
 	def, err := c.Component.getDefinitionByUID(defUID)
 	if err != nil {
 		return nil, err
 	}
-	return def.(*pipelinePB.ConnectorDefinition), nil
+
+	cd, ok := def.(*pipelinePB.ConnectorDefinition)
+	if !ok {
+		return nil, fmt.Errorf("invalid type for connector definition ID")
+	}
+
+	return cd, nil
 }
 
 // GetConnectorDefinitionByID gets the connector definition by definition id
@@ -202,7 +208,13 @@ func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *str
 	if err != nil {
 		return nil, err
 	}
-	return def.(*pipelinePB.ConnectorDefinition), nil
+
+	cd, ok := def.(*pipelinePB.ConnectorDefinition)
+	if !ok {
+		return nil, fmt.Errorf("invalid type for connector definition UID")
+	}
+
+	return cd, nil
 }
 
 // IsCredentialField checks if the target field is credential field

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -113,12 +113,18 @@ func (o *Operator) ListOperatorDefinitions() []*pipelinePB.OperatorDefinition {
 }
 
 // GetOperatorDefinitionByUID returns the operator definition by definition uid
-func (o *Operator) GetOperatorDefinitionByUID(defUID uuid.UUID, componentConfig *structpb.Struct) (*pipelinePB.OperatorDefinition, error) {
+func (o *Operator) GetOperatorDefinitionByUID(defUID uuid.UUID, _ /*componentConfig*/ *structpb.Struct) (*pipelinePB.OperatorDefinition, error) {
 	def, err := o.Component.getDefinitionByUID(defUID)
 	if err != nil {
 		return nil, err
 	}
-	return def.(*pipelinePB.OperatorDefinition), nil
+
+	od, ok := def.(*pipelinePB.OperatorDefinition)
+	if !ok {
+		return nil, fmt.Errorf("invalid type for operator definition UID")
+	}
+
+	return od, nil
 }
 
 // GetOperatorDefinitionByID returns the operator definition by definition id
@@ -127,5 +133,11 @@ func (o *Operator) GetOperatorDefinitionByID(defID string, componentConfig *stru
 	if err != nil {
 		return nil, err
 	}
-	return def.(*pipelinePB.OperatorDefinition), nil
+
+	od, ok := def.(*pipelinePB.OperatorDefinition)
+	if !ok {
+		return nil, fmt.Errorf("invalid type for operator definition ID")
+	}
+
+	return od, nil
 }

--- a/tools/compogen/cmd/testdata/readme-connector.txt
+++ b/tools/compogen/cmd/testdata/readme-connector.txt
@@ -18,7 +18,7 @@ cmp pkg/dummy/README.mdx want-readme.mdx
     "public": true,
     "id": "dummy",
     "title": "Dummy",
-    "description": "Performs an action",
+    "description": "Perform an action",
     "prerequisites": "An account at [dummy.io](https://dummy.io) is required.",
     "type": "CONNECTOR_TYPE_DATA",
     "spec": {
@@ -87,7 +87,7 @@ draft: false
 description: "Learn about how to set up a VDP Dummy connector https://github.com/instill-ai/vdp"
 ---
 
-The Dummy component is a data connector that performs an action.
+The Dummy component is a data connector that allows users to perform an action.
 It can carry out the following tasks:
 
 - [Dummy](#dummy)

--- a/tools/compogen/cmd/testdata/readme-operator.txt
+++ b/tools/compogen/cmd/testdata/readme-operator.txt
@@ -33,7 +33,7 @@ cmp pkg/dummy/README.mdx want-readme.mdx
     "spec": {},
     "id": "dummy",
     "title": "Dummy",
-    "description": "Performs an action",
+    "description": "Perform an action",
     "version": "0.1.0-alpha",
     "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/dummy/v0"
   }
@@ -159,7 +159,7 @@ draft: false
 description: "Learn about how to set up a VDP Dummy operator https://github.com/instill-ai/vdp"
 ---
 
-The Dummy component is an operator that performs an action.
+The Dummy component is an operator that allows users to perform an action.
 It can carry out the following tasks:
 
 - [Dummy](#dummy)


### PR DESCRIPTION
Because

- `description` field in operator is now in imperative format
- When a connector / operator definition is fetched, it is pulled from the component definition list. When an error occurs, we can't know if it's because it doesn't exist or because the type is wrong.

This commit

- Updates `compogen` tests
- Improves the error messages for the "get by ID / UID" component definition methods.
