### PR TITLE
fix(compogen): better installation command

### DIFF
--- a/tools/compogen/README.md
+++ b/tools/compogen/README.md
@@ -7,9 +7,7 @@ documentation.
 ## Installation
 
 ```shell
-git clone https://github.com/instill-ai/component
-cd component/tools/compogen
-go install .
+go install github.com/instill-ai/component/tools/compogen@latest
 ```
 
 ## Generate the documentation of a component


### PR DESCRIPTION
Because

- Installing the tool doesn't require `git`, only `go`

This commit

- Updates `compogen`'s README to simplify the installation command
