### PR TITLE
feat: adjust `Test()` interface

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -149,7 +149,7 @@ In [component.go](https://github.com/instill-ai/component/blob/main/pkg/base/com
 // All connectors need to implement this interface
 type IConnector interface {
     CreateExecution(defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error)
-    Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error)
+    Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (bool, error)
 }
 
 // All operators need to implement this interface

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240415024335-3b7581a069fd
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/itchyny/gojq v0.12.14
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73 h1:3YT3WV9F1eltn5x3AhtOuRDO2zY3Aud6nk/som9YQvs=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240415024335-3b7581a069fd h1:Q7Zm2Rc3Fg+r/6WQtwLY0nyoCCiSy6kJ4W8SQT/WQeQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240415024335-3b7581a069fd/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=
 github.com/instill-ai/x v0.4.0-alpha/go.mod h1:L6jmDPrUou6XskaLXZuK/gDeitdoPa9yE8ONKt1ZwCw=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=

--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -19,7 +19,7 @@ type IConnector interface {
 
 	// Functions that need to be implemented for all connectors
 	// Test connection
-	Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error)
+	Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error
 
 	// Functions that shared for all connectors
 	// Load connector definitions from json files

--- a/pkg/connector/archetypeai/v0/connector_test.go
+++ b/pkg/connector/archetypeai/v0/connector_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/component/pkg/connector/util/httpclient"
-	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 	"github.com/instill-ai/x/errmsg"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -309,8 +308,7 @@ func TestConnector_Test(t *testing.T) {
 	defID := uuid.Must(uuid.NewV4())
 
 	c.Run("ok - connected", func(c *qt.C) {
-		got, err := connector.Test(defID, nil, logger)
+		err := connector.Test(defID, nil, logger)
 		c.Check(err, qt.IsNil)
-		c.Check(got, qt.Equals, pb.Connector_STATE_CONNECTED)
 	})
 }

--- a/pkg/connector/archetypeai/v0/main.go
+++ b/pkg/connector/archetypeai/v0/main.go
@@ -16,8 +16,6 @@ import (
 	"github.com/instill-ai/component/pkg/connector/util"
 	"github.com/instill-ai/component/pkg/connector/util/httpclient"
 	"github.com/instill-ai/x/errmsg"
-
-	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -219,12 +217,12 @@ func (e *execution) uploadFile(in *structpb.Struct) (*structpb.Struct, error) {
 }
 
 // Test checks the connectivity of the connector.
-func (c *connector) Test(_ uuid.UUID, _ *structpb.Struct, _ *zap.Logger) (pb.Connector_State, error) {
+func (c *connector) Test(_ uuid.UUID, _ *structpb.Struct, _ *zap.Logger) error {
 	// TODO Archetype AI API is not public yet. We could test the connection
 	// by calling one of the endpoints used in the available tasks. However,
 	// these are not designed for specifically for this purpose. When we know
 	// of an endpoint that's more suited for this, it should be used instead.
-	return pb.Connector_STATE_CONNECTED, nil
+	return nil
 }
 
 func getAPIKey(config *structpb.Struct) string {

--- a/pkg/connector/bigquery/v0/main.go
+++ b/pkg/connector/bigquery/v0/main.go
@@ -14,8 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -114,15 +112,15 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 
 	client, err := NewClient(getJSONKey(config), getProjectID(config))
 	if err != nil || client == nil {
-		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating BigQuery client: %v", err)
+		return fmt.Errorf("error creating BigQuery client: %v", err)
 	}
 	defer client.Close()
 	if client.Project() == getProjectID(config) {
-		return pipelinePB.Connector_STATE_CONNECTED, nil
+		return nil
 	}
-	return pipelinePB.Connector_STATE_DISCONNECTED, errors.New("project ID does not match")
+	return errors.New("project ID does not match")
 }

--- a/pkg/connector/googlecloudstorage/v0/main.go
+++ b/pkg/connector/googlecloudstorage/v0/main.go
@@ -14,8 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -116,15 +114,15 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 
 	client, err := NewClient(getJSONKey(config))
 	if err != nil {
-		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating GCS client: %v", err)
+		return fmt.Errorf("error creating GCS client: %v", err)
 	}
 	if client == nil {
-		return pipelinePB.Connector_STATE_DISCONNECTED, fmt.Errorf("GCS client is nil")
+		return fmt.Errorf("GCS client is nil")
 	}
 	defer client.Close()
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }

--- a/pkg/connector/googlesearch/v0/main.go
+++ b/pkg/connector/googlesearch/v0/main.go
@@ -15,8 +15,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -120,14 +118,14 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 
 	service, err := NewService(getAPIKey(config))
 	if err != nil || service == nil {
-		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating Google custom search service: %v", err)
+		return fmt.Errorf("error creating Google custom search service: %v", err)
 	}
 	if service == nil {
-		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating Google custom search service: %v", err)
+		return fmt.Errorf("error creating Google custom search service: %v", err)
 	}
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }

--- a/pkg/connector/huggingface/v0/main.go
+++ b/pkg/connector/huggingface/v0/main.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/x/errmsg"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -569,16 +567,16 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	req := newClient(config, logger).R()
 	resp, err := req.Get("")
 	if err != nil {
-		return pipelinePB.Connector_STATE_ERROR, err
+		return err
 	}
 
 	if resp.IsError() {
-		return pipelinePB.Connector_STATE_DISCONNECTED, nil
+		return fmt.Errorf("connection error")
 	}
 
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }

--- a/pkg/connector/instill/v0/main.go
+++ b/pkg/connector/instill/v0/main.go
@@ -185,7 +185,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return result, err
 }
 
-func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	gRPCCLient, gRPCCLientConn := initModelPublicServiceClient(getModelServerURL(config))
 	if gRPCCLientConn != nil {
 		defer gRPCCLientConn.Close()
@@ -193,10 +193,10 @@ func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logge
 	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(config))
 	_, err := gRPCCLient.ListModels(ctx, &modelPB.ListModelsRequest{})
 	if err != nil {
-		return pipelinePB.Connector_STATE_ERROR, err
+		return err
 	}
 
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }
 
 func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {

--- a/pkg/connector/main.go
+++ b/pkg/connector/main.go
@@ -81,7 +81,7 @@ func (c *Connector) CreateExecution(defUID uuid.UUID, task string, config *struc
 	return c.connectorUIDMap[defUID].CreateExecution(defUID, task, config, logger)
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	return c.connectorUIDMap[defUID].Test(defUID, config, logger)
 }
 

--- a/pkg/connector/numbers/v0/main.go
+++ b/pkg/connector/numbers/v0/main.go
@@ -18,8 +18,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const urlRegisterAsset = "https://api.numbersprotocol.io/api/v3/assets/"
@@ -276,11 +274,11 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 
 	req, err := http.NewRequest("GET", urlUserMe, nil)
 	if err != nil {
-		return pipelinePB.Connector_STATE_ERROR, nil
+		return err
 	}
 	req.Header.Set("Authorization", getToken(config))
 
@@ -293,10 +291,10 @@ func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.
 		defer res.Body.Close()
 	}
 	if err != nil {
-		return pipelinePB.Connector_STATE_ERROR, nil
+		return err
 	}
 	if res.StatusCode == http.StatusOK {
-		return pipelinePB.Connector_STATE_CONNECTED, nil
+		return fmt.Errorf("connection error")
 	}
-	return pipelinePB.Connector_STATE_ERROR, nil
+	return nil
 }

--- a/pkg/connector/openai/v0/connector_test.go
+++ b/pkg/connector/openai/v0/connector_test.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/connector/util/httpclient"
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 	"github.com/instill-ai/x/errmsg"
 )
 
@@ -152,9 +151,8 @@ func TestConnector_Test(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := connector.Test(defID, config, logger)
+		err = connector.Test(defID, config, logger)
 		c.Check(err, qt.IsNotNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_ERROR)
 
 		wantMsg := "OpenAI responded with a 401 status code. Incorrect API key provided."
 		c.Check(errmsg.Message(err), qt.Equals, wantMsg)
@@ -177,9 +175,8 @@ func TestConnector_Test(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := connector.Test(defID, config, logger)
+		err = connector.Test(defID, config, logger)
 		c.Check(err, qt.IsNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_DISCONNECTED)
 	})
 
 	c.Run("ok - connected", func(c *qt.C) {
@@ -199,8 +196,7 @@ func TestConnector_Test(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := connector.Test(defID, config, logger)
+		err = connector.Test(defID, config, logger)
 		c.Check(err, qt.IsNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_CONNECTED)
 	})
 }

--- a/pkg/connector/openai/v0/connector_test.go
+++ b/pkg/connector/openai/v0/connector_test.go
@@ -176,7 +176,7 @@ func TestConnector_Test(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		err = connector.Test(defID, config, logger)
-		c.Check(err, qt.IsNil)
+		c.Check(err, qt.IsNotNil)
 	})
 
 	c.Run("ok - connected", func(c *qt.C) {

--- a/pkg/connector/openai/v0/main.go
+++ b/pkg/connector/openai/v0/main.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 	"github.com/instill-ai/x/errmsg"
 )
 
@@ -328,17 +327,17 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 }
 
 // Test checks the connector state.
-func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	models := ListModelsResponse{}
 	req := newClient(config, logger).R().SetResult(&models)
 
 	if _, err := req.Get(listModelsPath); err != nil {
-		return pipelinePB.Connector_STATE_ERROR, err
+		return err
 	}
 
 	if len(models.Data) == 0 {
-		return pipelinePB.Connector_STATE_DISCONNECTED, nil
+		return fmt.Errorf("no models")
 	}
 
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }

--- a/pkg/connector/pinecone/v0/main.go
+++ b/pkg/connector/pinecone/v0/main.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/component/pkg/connector/util/httpclient"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -141,7 +139,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	//TODO: change this
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }

--- a/pkg/connector/redis/v0/main.go
+++ b/pkg/connector/redis/v0/main.go
@@ -11,8 +11,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -113,17 +111,17 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	client, err := NewClient(config)
 	if err != nil {
-		return pipelinePB.Connector_STATE_ERROR, err
+		return err
 	}
 	defer client.Close()
 
 	// Ping the Redis server to check the connection
 	_, err = client.Ping(context.Background()).Result()
 	if err != nil {
-		return pipelinePB.Connector_STATE_DISCONNECTED, err
+		return err
 	}
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }

--- a/pkg/connector/restapi/v0/connector_test.go
+++ b/pkg/connector/restapi/v0/connector_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/component/pkg/connector/util/httpclient"
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 	"github.com/instill-ai/x/errmsg"
 )
 
@@ -174,9 +173,8 @@ func TestConnector_Test(t *testing.T) {
 		srv := httptest.NewServer(h)
 		c.Cleanup(srv.Close)
 
-		got, err := connector.Test(defID, cfg(noAuthType), logger)
+		err := connector.Test(defID, cfg(noAuthType), logger)
 		c.Check(err, qt.IsNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_CONNECTED)
 	})
 }
 

--- a/pkg/connector/restapi/v0/main.go
+++ b/pkg/connector/restapi/v0/main.go
@@ -165,9 +165,9 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	// we don't need to validate the connection since no url setting here
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }
 
 func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {

--- a/pkg/connector/stabilityai/v0/connector_test.go
+++ b/pkg/connector/stabilityai/v0/connector_test.go
@@ -279,7 +279,7 @@ func TestConnector_Test(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		err = connector.Test(defID, config, logger)
-		c.Check(err, qt.IsNil)
+		c.Check(err, qt.IsNotNil)
 	})
 
 	c.Run("ok - connected", func(c *qt.C) {

--- a/pkg/connector/stabilityai/v0/connector_test.go
+++ b/pkg/connector/stabilityai/v0/connector_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/component/pkg/connector/util/httpclient"
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 	"github.com/instill-ai/x/errmsg"
 )
 
@@ -255,9 +254,8 @@ func TestConnector_Test(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := connector.Test(defID, config, logger)
+		err = connector.Test(defID, config, logger)
 		c.Check(err, qt.IsNotNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_ERROR)
 
 		wantMsg := "Stability AI responded with a 401 status code. Incorrect API key provided"
 		c.Check(errmsg.Message(err), qt.Equals, wantMsg)
@@ -280,9 +278,8 @@ func TestConnector_Test(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := connector.Test(defID, config, logger)
+		err = connector.Test(defID, config, logger)
 		c.Check(err, qt.IsNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_DISCONNECTED)
 	})
 
 	c.Run("ok - connected", func(c *qt.C) {
@@ -302,8 +299,7 @@ func TestConnector_Test(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := connector.Test(defID, config, logger)
+		err = connector.Test(defID, config, logger)
 		c.Check(err, qt.IsNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_CONNECTED)
 	})
 }

--- a/pkg/connector/stabilityai/v0/main.go
+++ b/pkg/connector/stabilityai/v0/main.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/x/errmsg"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -140,17 +138,17 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 }
 
 // Test checks the connector state.
-func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
 	var engines []Engine
 	req := newClient(config, logger).R().SetResult(&engines)
 
 	if _, err := req.Get(listEnginesPath); err != nil {
-		return pipelinePB.Connector_STATE_ERROR, err
+		return err
 	}
 
 	if len(engines) == 0 {
-		return pipelinePB.Connector_STATE_DISCONNECTED, nil
+		return fmt.Errorf("no engines")
 	}
 
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+	return nil
 }

--- a/pkg/connector/website/v0/main.go
+++ b/pkg/connector/website/v0/main.go
@@ -10,8 +10,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (
@@ -86,6 +84,6 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
-	return pipelinePB.Connector_STATE_CONNECTED, nil
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
+	return nil
 }


### PR DESCRIPTION
Because

- We can simplify the `Test()` function in the connector to use only the error message instead of an additional enum.

This commit

- Adjusts `Test()` interface and removes the state enum.
- Adopts latest protogengo.
