### PR TITLE
feat: merge resource spec into component spec

### DIFF
--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -77,6 +77,8 @@ func (c *Connector) LoadConnectorDefinition(definitionJSONBytes []byte, tasksJSO
 	if err != nil {
 		return err
 	}
+
+	// deprecated, will be removed soon
 	def.Spec.ResourceSpecification, err = c.refineResourceSpec(def.Spec.ResourceSpecification)
 	if err != nil {
 		return err
@@ -88,6 +90,9 @@ func (c *Connector) LoadConnectorDefinition(definitionJSONBytes []byte, tasksJSO
 	if err != nil {
 		return err
 	}
+	connectionPropStruct := &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	connectionPropStruct.Fields["connection"] = structpb.NewStructValue(def.Spec.ResourceSpecification)
+	def.Spec.ComponentSpecification.Fields["properties"] = structpb.NewStructValue(connectionPropStruct)
 
 	def.Spec.DataSpecifications, err = c.generateDataSpecs(def.Title, availableTasks)
 	if err != nil {

--- a/pkg/base/testdata/wantConnectorDefinition.json
+++ b/pkg/base/testdata/wantConnectorDefinition.json
@@ -129,6 +129,28 @@
           "type": "object"
         }
       ],
+      "properties": {
+        "connection": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": true,
+          "instillShortDescription": "",
+          "properties": {
+            "api_key": {
+              "description": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
+              "instillCredentialField": true,
+              "instillShortDescription": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
+              "instillUIOrder": 0,
+              "title": "API Key",
+              "type": "string"
+            }
+          },
+          "required": [
+            "api_key"
+          ],
+          "title": "OpenAI Connector Resource",
+          "type": "object"
+        }
+      },
       "title": "OpenAI Component",
       "type": "object"
     },


### PR DESCRIPTION
Because

- We've retired the connector resource, there is no need to have two specifications for resource and component. We can merge them into one.

This commit:

- Merges the resource spec into the component spec.

Note:

- We keep the old resource spec for now. It will be removed soon.