### PR TITLE
refactor: simplify interface structure

### DIFF
--- a/pkg/base/connector_test.go
+++ b/pkg/base/connector_test.go
@@ -23,8 +23,8 @@ func TestConnector_ListConnectorDefinitions(t *testing.T) {
 	c := qt.New(t)
 	logger := zap.NewNop()
 
-	conn := Connector{
-		Component: Component{Logger: logger},
+	conn := BaseConnector{
+		Logger: logger,
 	}
 
 	err := conn.LoadConnectorDefinition(
@@ -33,9 +33,7 @@ func TestConnector_ListConnectorDefinitions(t *testing.T) {
 		map[string][]byte{"additional.json": connectorAdditionalJSON})
 	c.Assert(err, qt.IsNil)
 
-	defs := conn.ListConnectorDefinitions(false)
-	c.Assert(defs, qt.HasLen, 1)
-
-	got := defs[0]
+	got, err := conn.GetConnectorDefinition(nil)
+	c.Assert(err, qt.IsNil)
 	c.Check(wantConnectorDefinitionJSON, qt.JSONEquals, got)
 }

--- a/pkg/base/execution.go
+++ b/pkg/base/execution.go
@@ -6,53 +6,24 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gofrs/uuid"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// IExecution is the interface that all executions need to implement
+type ExecutionWrapper struct {
+	Execution IExecution
+}
+
 type IExecution interface {
-	// Functions that shared for all connectors
-	// Validate the input and output format
-	Validate(data []*structpb.Struct, jsonSchema string, target string) error
-
-	// Execute
 	GetTask() string
-	GetConfig() *structpb.Struct
-	GetUID() uuid.UUID
+	GetLogger() *zap.Logger
+	GetUsageHandler() UsageHandler
+	GetTaskInputSchema() string
+	GetTaskOutputSchema() string
 
-	// Execute
-	ExecuteWithValidation(inputs []*structpb.Struct) ([]*structpb.Struct, error)
-	// execute
-	Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error)
-}
-
-// Execution is the base struct for all executions
-type Execution struct {
-	Logger             *zap.Logger
-	Component          IComponent
-	ComponentExecution IExecution
-	UID                uuid.UUID
-	Config             *structpb.Struct
-	Task               string
-}
-
-// GetUID returns the uid of the execution
-func (e *Execution) GetUID() uuid.UUID {
-	return e.UID
-}
-
-// GetTask returns the task of the execution
-func (e *Execution) GetTask() string {
-	return e.Task
-}
-
-// GetConfig returns the config of the execution
-func (e *Execution) GetConfig() *structpb.Struct {
-	return e.Config
+	Execute([]*structpb.Struct) ([]*structpb.Struct, error)
 }
 
 func FormatErrors(inputPath string, e jsonschema.Detailed, errors *[]string) {
@@ -74,7 +45,7 @@ func FormatErrors(inputPath string, e jsonschema.Detailed, errors *[]string) {
 }
 
 // Validate the input and output format
-func (e *Execution) Validate(data []*structpb.Struct, jsonSchema string, target string) error {
+func Validate(data []*structpb.Struct, jsonSchema string, target string) error {
 
 	schStruct := &structpb.Struct{}
 	err := protojson.Unmarshal([]byte(jsonSchema), schStruct)
@@ -138,62 +109,32 @@ func (e *Execution) Validate(data []*structpb.Struct, jsonSchema string, target 
 }
 
 // ExecuteWithValidation executes the execution with validation
-func (e *Execution) ExecuteWithValidation(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
-	task := e.GetTask()
-	if task == "" {
-		keys := make([]string, 0, len(e.Component.GetTaskInputSchemas()))
-		for k := range e.Component.GetTaskInputSchemas() {
-			keys = append(keys, k)
-		}
-		if len(keys) != 1 {
-			return nil, fmt.Errorf("must specify a task")
-		}
-		task = keys[0]
-	}
+func (e *ExecutionWrapper) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 
-	if _, ok := e.Component.GetTaskInputSchemas()[task]; !ok {
-		return nil, fmt.Errorf("no task %s", e.GetTask())
-	}
-
-	if err := e.Validate(inputs, e.Component.GetTaskInputSchemas()[task], "inputs"); err != nil {
+	if err := Validate(inputs, e.Execution.GetTaskInputSchema(), "inputs"); err != nil {
 		return nil, err
 	}
 
-	if e.Component.GetUsageHandler() != nil {
-		if err := e.Component.GetUsageHandler().Check(); err != nil {
+	if e.Execution.GetUsageHandler() != nil {
+		if err := e.Execution.GetUsageHandler().Check(); err != nil {
 			return nil, err
 		}
 	}
 
-	outputs, err := e.ComponentExecution.Execute(inputs)
+	outputs, err := e.Execution.Execute(inputs)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := e.Validate(outputs, e.Component.GetTaskOutputSchemas()[task], "outputs"); err != nil {
+	if err := Validate(outputs, e.Execution.GetTaskOutputSchema(), "outputs"); err != nil {
 		return nil, err
 	}
 
-	if e.Component.GetUsageHandler() != nil {
-		if err := e.Component.GetUsageHandler().Collect(); err != nil {
+	if e.Execution.GetUsageHandler() != nil {
+		if err := e.Execution.GetUsageHandler().Collect(); err != nil {
 			return nil, err
 		}
 	}
 
 	return outputs, err
-}
-
-// CreateExecutionHelper creates a new execution
-func CreateExecutionHelper(e IExecution, comp IComponent, defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) Execution {
-
-	baseExecution := Execution{
-		Logger:             logger,
-		Component:          comp,
-		ComponentExecution: e,
-		UID:                defUID,
-		Config:             config,
-		Task:               task,
-	}
-
-	return baseExecution
 }

--- a/pkg/base/operator_test.go
+++ b/pkg/base/operator_test.go
@@ -21,16 +21,14 @@ func TestOperator_ListOperatorDefinitions(t *testing.T) {
 	c := qt.New(t)
 	logger := zap.NewNop()
 
-	conn := Operator{
-		Component: Component{Logger: logger},
+	op := BaseOperator{
+		Logger: logger,
 	}
 
-	err := conn.LoadOperatorDefinition(operatorDefJSON, operatorTasksJSON, nil)
+	err := op.LoadOperatorDefinition(operatorDefJSON, operatorTasksJSON, nil)
 	c.Assert(err, qt.IsNil)
 
-	defs := conn.ListOperatorDefinitions(false)
-	c.Assert(defs, qt.HasLen, 1)
-
-	got := defs[0]
+	got, err := op.GetOperatorDefinition(nil)
+	c.Assert(err, qt.IsNil)
 	c.Check(wantOperatorDefinitionJSON, qt.JSONEquals, got)
 }

--- a/pkg/base/testdata/wantOperatorDefinition.json
+++ b/pkg/base/testdata/wantOperatorDefinition.json
@@ -1,4 +1,5 @@
 {
+  "name": "operator-definitions/json",
   "uid": "28f53d15-6150-46e6-99aa-f76b70a926c0",
   "id": "json",
   "title": "JSON",

--- a/pkg/connector/airbyte/v0/main.go
+++ b/pkg/connector/airbyte/v0/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -19,43 +18,42 @@ var definitionJSON []byte
 var tasksJSON []byte
 
 var once sync.Once
-var connector base.IConnector
+var con *connector
 
-type Connector struct {
-	base.Connector
+type connector struct {
+	base.BaseConnector
 }
 
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseConnectorExecution
 }
 
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IConnector {
+func Init(l *zap.Logger, u base.UsageHandler) *connector {
 	once.Do(func() {
-
-		connector = &Connector{
-			Connector: base.Connector{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		con = &connector{
+			BaseConnector: base.BaseConnector{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-
-		err := connector.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
+		err := con.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
-
+			panic(err)
 		}
-
 	})
-	return connector
+	return con
 }
 
-func (c *Connector) CreateExecution(defUID uuid.UUID, task string, connection *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
+func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+	}}, nil
+}
+
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	return nil, fmt.Errorf("the Airbyte connector has been removed")
 }
 
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
-	return nil, fmt.Errorf("the Airbyte connector has been removed")
-}
-
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
+func (c *connector) Test(sysVars map[string]any, connection *structpb.Struct) error {
 	return fmt.Errorf("the Airbyte connector has been removed")
 }

--- a/pkg/connector/archetypeai/v0/connector_test.go
+++ b/pkg/connector/archetypeai/v0/connector_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/gofrs/uuid"
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/component/pkg/connector/util/httpclient"
 	"github.com/instill-ai/x/errmsg"
@@ -227,7 +226,6 @@ func TestConnector_Execute(t *testing.T) {
 
 	logger := zap.NewNop()
 	connector := Init(logger, nil)
-	defID := uuid.Must(uuid.NewV4())
 
 	for _, tc := range testcases {
 		c.Run(tc.name, func(c *qt.C) {
@@ -256,18 +254,18 @@ func TestConnector_Execute(t *testing.T) {
 			srv := httptest.NewServer(h)
 			c.Cleanup(srv.Close)
 
-			config, _ := structpb.NewStruct(map[string]any{
+			connection, _ := structpb.NewStruct(map[string]any{
 				"base_path": srv.URL,
 				"api_key":   apiKey,
 			})
 
-			exec, err := connector.CreateExecution(defID, tc.task, config, logger)
+			exec, err := connector.CreateExecution(nil, connection, tc.task)
 			c.Assert(err, qt.IsNil)
 
 			pbIn, err := base.ConvertToStructpb(tc.in)
 			c.Assert(err, qt.IsNil)
 
-			got, err := exec.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
 			if tc.wantErr != "" {
 				c.Check(errmsg.Message(err), qt.Matches, tc.wantErr)
 				return
@@ -288,13 +286,12 @@ func TestConnector_CreateExecution(t *testing.T) {
 
 	logger := zap.NewNop()
 	connector := Init(logger, nil)
-	defID := uuid.Must(uuid.NewV4())
 
 	c.Run("nok - unsupported task", func(c *qt.C) {
 		task := "FOOBAR"
 		want := fmt.Sprintf("%s task is not supported.", task)
 
-		_, err := connector.CreateExecution(defID, task, new(structpb.Struct), logger)
+		_, err := connector.CreateExecution(nil, new(structpb.Struct), task)
 		c.Check(err, qt.IsNotNil)
 		c.Check(errmsg.Message(err), qt.Equals, want)
 	})
@@ -305,10 +302,9 @@ func TestConnector_Test(t *testing.T) {
 
 	logger := zap.NewNop()
 	connector := Init(logger, nil)
-	defID := uuid.Must(uuid.NewV4())
 
 	c.Run("ok - connected", func(c *qt.C) {
-		err := connector.Test(defID, nil, logger)
+		err := connector.Test(nil, nil)
 		c.Check(err, qt.IsNil)
 	})
 }

--- a/pkg/connector/googlesearch/v0/main.go
+++ b/pkg/connector/googlesearch/v0/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/api/customsearch/v1"
 	"google.golang.org/api/option"
@@ -28,35 +27,36 @@ var definitionJSON []byte
 var tasksJSON []byte
 
 var once sync.Once
-var connector base.IConnector
+var con *connector
 
-type Connector struct {
-	base.Connector
+type connector struct {
+	base.BaseConnector
 }
 
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseConnectorExecution
 }
 
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IConnector {
+func Init(l *zap.Logger, u base.UsageHandler) *connector {
 	once.Do(func() {
-		connector = &Connector{
-			Connector: base.Connector{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		con = &connector{
+			BaseConnector: base.BaseConnector{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-		err := connector.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
+		err := con.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
+			panic(err)
 		}
 	})
-	return connector
+	return con
 }
 
-func (c *Connector) CreateExecution(defUID uuid.UUID, task string, connection *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
-	e := &Execution{}
-	e.Execution = base.CreateExecutionHelper(e, c, defUID, task, connection, logger)
-	return e, nil
+func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+	}}, nil
 }
 
 // NewService creates a Google custom search service
@@ -72,13 +72,13 @@ func getSearchEngineID(config *structpb.Struct) string {
 	return config.GetFields()["cse_id"].GetStringValue()
 }
 
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 
-	service, err := NewService(getAPIKey(e.Config))
+	service, err := NewService(getAPIKey(e.Connection))
 	if err != nil || service == nil {
 		return nil, fmt.Errorf("error creating Google custom search service: %v", err)
 	}
-	cseListCall := service.Cse.List().Cx(getSearchEngineID(e.Config))
+	cseListCall := service.Cse.List().Cx(getSearchEngineID(e.Connection))
 
 	outputs := []*structpb.Struct{}
 
@@ -118,9 +118,9 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
+func (c *connector) Test(sysVars map[string]any, connection *structpb.Struct) error {
 
-	service, err := NewService(getAPIKey(config))
+	service, err := NewService(getAPIKey(connection))
 	if err != nil || service == nil {
 		return fmt.Errorf("error creating Google custom search service: %v", err)
 	}

--- a/pkg/connector/instill/v0/image_classification.go
+++ b/pkg/connector/instill/v0/image_classification.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeImageClassification(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeImageClassification(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -47,7 +47,7 @@ func (e *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/image_to_image.go
+++ b/pkg/connector/instill/v0/image_to_image.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -65,7 +65,7 @@ func (e *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/instance_segmentation.go
+++ b/pkg/connector/instill/v0/instance_segmentation.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -45,7 +45,7 @@ func (e *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/keypoint_detection.go
+++ b/pkg/connector/instill/v0/keypoint_detection.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -41,7 +41,7 @@ func (e *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/llm_utils.go
+++ b/pkg/connector/instill/v0/llm_utils.go
@@ -29,7 +29,7 @@ type LLMInput struct {
 	ExtraParams *structpb.Struct
 }
 
-func (e *Execution) convertLLMInput(input *structpb.Struct) *LLMInput {
+func (e *execution) convertLLMInput(input *structpb.Struct) *LLMInput {
 	llmInput := &LLMInput{
 		Prompt: input.GetFields()["prompt"].GetStringValue(),
 	}

--- a/pkg/connector/instill/v0/object_detection.go
+++ b/pkg/connector/instill/v0/object_detection.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeObjectDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -48,7 +48,7 @@ func (e *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 		TaskInputs: taskInputs,
 	}
 
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/ocr.go
+++ b/pkg/connector/instill/v0/ocr.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -41,7 +41,7 @@ func (e *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/semantic_segmentation.go
+++ b/pkg/connector/instill/v0/semantic_segmentation.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -45,7 +45,7 @@ func (e *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/text_generation.go
+++ b/pkg/connector/instill/v0/text_generation.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -44,7 +44,7 @@ func (e *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/text_generation_chat.go
+++ b/pkg/connector/instill/v0/text_generation_chat.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
@@ -44,7 +44,7 @@ func (e *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/text_to_image.go
+++ b/pkg/connector/instill/v0/text_to_image.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -56,7 +56,7 @@ func (e *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/unspecified.go
+++ b/pkg/connector/instill/v0/unspecified.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func (e *Execution) executeUnspecified(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeUnspecified(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}

--- a/pkg/connector/instill/v0/visual_question_answering.go
+++ b/pkg/connector/instill/v0/visual_question_answering.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (e *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -44,7 +44,7 @@ func (e *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Config))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -51,7 +51,7 @@ func TestOpenAITextGeneration(t *testing.T) {
 	exec, err := conn.CreateExecution(uid, "TASK_TEXT_GENERATION", config, logger)
 	c.Assert(err, qt.IsNil)
 
-	op, err := exec.Execute([]*structpb.Struct{in})
+	op, err := exec.Execution.Execute([]*structpb.Struct{in})
 
 	// This assumes invalid API credentials that trigger a 401 API error. We
 	// should check for valid behaviour in integration tests, although

--- a/pkg/connector/pinecone/v0/main.go
+++ b/pkg/connector/pinecone/v0/main.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"sync"
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -28,35 +27,36 @@ var definitionJSON []byte
 var tasksJSON []byte
 
 var once sync.Once
-var connector base.IConnector
+var con *connector
 
-type Connector struct {
-	base.Connector
+type connector struct {
+	base.BaseConnector
 }
 
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseConnectorExecution
 }
 
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IConnector {
+func Init(l *zap.Logger, u base.UsageHandler) *connector {
 	once.Do(func() {
-		connector = &Connector{
-			Connector: base.Connector{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		con = &connector{
+			BaseConnector: base.BaseConnector{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-		err := connector.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
+		err := con.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
+			panic(err)
 		}
 	})
-	return connector
+	return con
 }
 
-func (c *Connector) CreateExecution(defUID uuid.UUID, task string, connection *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
-	e := &Execution{}
-	e.Execution = base.CreateExecutionHelper(e, c, defUID, task, connection, logger)
-	return e, nil
+func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+	}}, nil
 }
 
 func newClient(config *structpb.Struct, logger *zap.Logger) *httpclient.Client {
@@ -78,8 +78,8 @@ func getURL(config *structpb.Struct) string {
 	return config.GetFields()["url"].GetStringValue()
 }
 
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
-	req := newClient(e.Config, e.Logger).R()
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+	req := newClient(e.Connection, e.GetLogger()).R()
 	outputs := []*structpb.Struct{}
 
 	for _, input := range inputs {
@@ -139,7 +139,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
+func (c *connector) Test(sysVars map[string]any, connection *structpb.Struct) error {
 	//TODO: change this
 	return nil
 }

--- a/pkg/connector/redis/v0/main.go
+++ b/pkg/connector/redis/v0/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -25,43 +24,44 @@ var (
 	//go:embed config/tasks.json
 	tasksJSON []byte
 
-	once      sync.Once
-	connector base.IConnector
+	once sync.Once
+	con  *connector
 )
 
-type Connector struct {
-	base.Connector
+type connector struct {
+	base.BaseConnector
 }
 
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseConnectorExecution
 }
 
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IConnector {
+func Init(l *zap.Logger, u base.UsageHandler) *connector {
 	once.Do(func() {
-		connector = &Connector{
-			Connector: base.Connector{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		con = &connector{
+			BaseConnector: base.BaseConnector{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-		err := connector.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
+		err := con.LoadConnectorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
+			panic(err)
 		}
 	})
-	return connector
+	return con
 }
 
-func (c *Connector) CreateExecution(defUID uuid.UUID, task string, connection *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
-	e := &Execution{}
-	e.Execution = base.CreateExecutionHelper(e, c, defUID, task, connection, logger)
-	return e, nil
+func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+	}}, nil
 }
 
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
-	client, err := NewClient(e.Config)
+	client, err := NewClient(e.Connection)
 	if err != nil {
 		return outputs, err
 	}
@@ -111,8 +111,8 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) error {
-	client, err := NewClient(config)
+func (c *connector) Test(sysVars map[string]any, connection *structpb.Struct) error {
+	client, err := NewClient(connection)
 	if err != nil {
 		return err
 	}

--- a/pkg/connector/restapi/v0/connector_test.go
+++ b/pkg/connector/restapi/v0/connector_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -32,7 +31,6 @@ func TestConnector_Execute(t *testing.T) {
 
 	logger := zap.NewNop()
 	connector := Init(logger, nil)
-	defID := uuid.Must(uuid.NewV4())
 	reqBody := map[string]any{
 		"title": "Be the wheel",
 	}
@@ -40,11 +38,11 @@ func TestConnector_Execute(t *testing.T) {
 	c.Run("nok - unsupported task", func(c *qt.C) {
 		task := "FOOBAR"
 
-		exec, err := connector.CreateExecution(defID, task, cfg(noAuthType), logger)
+		exec, err := connector.CreateExecution(nil, cfg(noAuthType), task)
 		c.Assert(err, qt.IsNil)
 
 		pbIn := new(structpb.Struct)
-		_, err = exec.Execute([]*structpb.Struct{pbIn})
+		_, err = exec.Execution.Execute([]*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNotNil)
 
 		want := "FOOBAR task is not supported."
@@ -74,7 +72,7 @@ func TestConnector_Execute(t *testing.T) {
 		srv := httptest.NewServer(h)
 		c.Cleanup(srv.Close)
 
-		exec, err := connector.CreateExecution(defID, taskPost, cfg(basicAuthType), logger)
+		exec, err := connector.CreateExecution(nil, cfg(basicAuthType), taskPost)
 		c.Assert(err, qt.IsNil)
 
 		pbIn, err := base.ConvertToStructpb(TaskInput{
@@ -83,7 +81,7 @@ func TestConnector_Execute(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := exec.Execute([]*structpb.Struct{pbIn})
+		got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNil)
 
 		resp := got[0].AsMap()
@@ -104,7 +102,7 @@ func TestConnector_Execute(t *testing.T) {
 		srv := httptest.NewServer(h)
 		c.Cleanup(srv.Close)
 
-		exec, err := connector.CreateExecution(defID, taskPut, cfg(apiKeyType), logger)
+		exec, err := connector.CreateExecution(nil, cfg(apiKeyType), taskPut)
 		c.Assert(err, qt.IsNil)
 
 		pbIn, err := base.ConvertToStructpb(TaskInput{
@@ -114,7 +112,7 @@ func TestConnector_Execute(t *testing.T) {
 
 		c.Assert(err, qt.IsNil)
 
-		got, err := exec.Execute([]*structpb.Struct{pbIn})
+		got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNil)
 
 		resp := got[0].AsMap()
@@ -136,7 +134,7 @@ func TestConnector_Execute(t *testing.T) {
 		srv := httptest.NewServer(h)
 		c.Cleanup(srv.Close)
 
-		exec, err := connector.CreateExecution(defID, taskGet, cfg(bearerTokenType), logger)
+		exec, err := connector.CreateExecution(nil, cfg(bearerTokenType), taskGet)
 		c.Assert(err, qt.IsNil)
 
 		pbIn, err := base.ConvertToStructpb(TaskInput{
@@ -145,7 +143,7 @@ func TestConnector_Execute(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := exec.Execute([]*structpb.Struct{pbIn})
+		got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNil)
 
 		resp := got[0].AsMap()
@@ -159,7 +157,6 @@ func TestConnector_Test(t *testing.T) {
 
 	logger := zap.NewNop()
 	connector := Init(logger, nil)
-	defID := uuid.Must(uuid.NewV4())
 
 	c.Run("ok - connected (even with non-2xx status", func(c *qt.C) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -173,7 +170,7 @@ func TestConnector_Test(t *testing.T) {
 		srv := httptest.NewServer(h)
 		c.Cleanup(srv.Close)
 
-		err := connector.Test(defID, cfg(noAuthType), logger)
+		err := connector.Test(nil, cfg(noAuthType))
 		c.Check(err, qt.IsNil)
 	})
 }

--- a/pkg/operator/end/v0/config/definition.json
+++ b/pkg/operator/end/v0/config/definition.json
@@ -10,7 +10,7 @@
   "public": true,
   "spec": {},
   "title": "End",
-  "tombstone": false,
+  "tombstone": true,
   "uid": "4f39c8bc-8617-495d-80de-80d0f5397516",
   "version": "0.1.0",
   "source_url": "https://github.com/instill-ai/component/blob/main/pkg/operator/end/v0",

--- a/pkg/operator/end/v0/main.go
+++ b/pkg/operator/end/v0/main.go
@@ -2,51 +2,58 @@ package end
 
 import (
 	_ "embed"
+	"fmt"
 	"sync"
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
 )
 
-var (
-	//go:embed config/definition.json
-	definitionJSON []byte
-	//go:embed config/tasks.json
-	tasksJSON []byte
-	once      sync.Once
-	operator  base.IOperator
-)
+//go:embed config/definition.json
+var definitionJSON []byte
 
-type Operator struct {
-	base.Operator
+//go:embed config/tasks.json
+var tasksJSON []byte
+
+var once sync.Once
+var con *operator
+
+type operator struct {
+	base.BaseOperator
 }
 
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseOperatorExecution
 }
 
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IOperator {
+func Init(l *zap.Logger, u base.UsageHandler) *operator {
 	once.Do(func() {
-		operator = &Operator{
-			Operator: base.Operator{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		con = &operator{
+			BaseOperator: base.BaseOperator{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-		err := operator.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
+		err := con.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
+			panic(err)
 		}
 	})
-	return operator
+	return con
 }
 
-func (o *Operator) CreateExecution(defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
-	panic("this is a special pipeline operator, we should not implement this function")
+func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+	}}, nil
 }
 
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
-	panic("this is a special pipeline operator, we should not implement this function")
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+	return nil, fmt.Errorf("the Airbyte operator has been removed")
+}
+
+func (o *operator) Test(sysVars map[string]any, connection *structpb.Struct) error {
+	return fmt.Errorf("the Airbyte operator has been removed")
 }

--- a/pkg/operator/image/v0/draw_test.go
+++ b/pkg/operator/image/v0/draw_test.go
@@ -37,14 +37,16 @@ func TestDrawClassification(t *testing.T) {
 
 	inputDog := &structpb.Struct{}
 	if err := json.Unmarshal(clsDogJSON, inputDog); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputs := []*structpb.Struct{
 		inputDog,
 	}
 
-	e := &Execution{}
+	e := &execution{}
 	e.Task = "TASK_DRAW_CLASSIFICATION"
 
 	if _, err := e.Execute(inputs); err != nil {
@@ -57,12 +59,16 @@ func TestDrawDetection(t *testing.T) {
 
 	inputCOCO1 := &structpb.Struct{}
 	if err := json.Unmarshal(detCOCO1JSON, inputCOCO1); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputCOCO2 := &structpb.Struct{}
 	if err := json.Unmarshal(detCOCO2JSON, inputCOCO2); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputs := []*structpb.Struct{
@@ -70,7 +76,7 @@ func TestDrawDetection(t *testing.T) {
 		// inputCOCO2,
 	}
 
-	e := &Execution{}
+	e := &execution{}
 	e.Task = "TASK_DRAW_DETECTION"
 
 	if _, err := e.Execute(inputs); err != nil {
@@ -83,12 +89,16 @@ func TestDrawKeypoint(t *testing.T) {
 
 	inputCOCO1 := &structpb.Struct{}
 	if err := json.Unmarshal(kpCOCO1JSON, inputCOCO1); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputCOCO2 := &structpb.Struct{}
 	if err := json.Unmarshal(kpCOCO2JSON, inputCOCO2); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputs := []*structpb.Struct{
@@ -96,7 +106,7 @@ func TestDrawKeypoint(t *testing.T) {
 		// inputCOCO2,
 	}
 
-	e := &Execution{}
+	e := &execution{}
 	e.Task = "TASK_DRAW_KEYPOINT"
 
 	if _, err := e.Execute(inputs); err != nil {
@@ -109,19 +119,23 @@ func TestDrawOCR(t *testing.T) {
 
 	inputMM := &structpb.Struct{}
 	if err := json.Unmarshal(ocrMMJSON, inputMM); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputCOCO2 := &structpb.Struct{}
 	if err := json.Unmarshal(kpCOCO2JSON, inputCOCO2); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputs := []*structpb.Struct{
 		inputMM,
 	}
 
-	e := &Execution{}
+	e := &execution{}
 	e.Task = "TASK_DRAW_OCR"
 
 	if _, err := e.Execute(inputs); err != nil {
@@ -134,17 +148,23 @@ func TestDrawInstanceSegmentation(t *testing.T) {
 
 	inputCOCO1 := &structpb.Struct{}
 	if err := json.Unmarshal(instSegCOCO1JSON, inputCOCO1); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputCOCO2 := &structpb.Struct{}
 	if err := json.Unmarshal(instSegCOCO2JSON, inputCOCO2); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputStomata := &structpb.Struct{}
 	if err := json.Unmarshal(instSegStomataJSON, inputStomata); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputs := []*structpb.Struct{
@@ -153,7 +173,7 @@ func TestDrawInstanceSegmentation(t *testing.T) {
 		inputStomata,
 	}
 
-	e := &Execution{}
+	e := &execution{}
 	e.Task = "TASK_DRAW_INSTANCE_SEGMENTATION"
 
 	if _, err := e.Execute(inputs); err != nil {
@@ -166,14 +186,16 @@ func TestDrawSemanticSegmentation(t *testing.T) {
 
 	inputCityscape := &structpb.Struct{}
 	if err := json.Unmarshal(semSegCityscapeJSON, inputCityscape); err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	inputs := []*structpb.Struct{
 		inputCityscape,
 	}
 
-	e := &Execution{}
+	e := &execution{}
 	e.Task = "TASK_DRAW_SEMANTIC_SEGMENTATION"
 
 	if _, err := e.Execute(inputs); err != nil {

--- a/pkg/operator/image/v0/main.go
+++ b/pkg/operator/image/v0/main.go
@@ -13,7 +13,6 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -26,44 +25,44 @@ var (
 	//go:embed config/tasks.json
 	tasksJSON []byte
 	once      sync.Once
-	operator  base.IOperator
+	op        *operator
 )
 
 // Operator is the derived operator
-type Operator struct {
-	base.Operator
+type operator struct {
+	base.BaseOperator
 }
 
 // Execution is the derived execution
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseOperatorExecution
 }
 
 // Init initializes the operator
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IOperator {
+func Init(l *zap.Logger, u base.UsageHandler) *operator {
 	once.Do(func() {
-		operator = &Operator{
-			Operator: base.Operator{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		op = &operator{
+			BaseOperator: base.BaseOperator{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-		err := operator.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
+		err := op.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
+			panic(err)
 		}
 	})
-	return operator
+	return op
 }
 
-// CreateExecution creates the derived execution
-func (o *Operator) CreateExecution(defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
-	e := &Execution{}
-	e.Execution = base.CreateExecutionHelper(e, o, defUID, task, config, logger)
-	return e, nil
+func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+	}}, nil
 }
 
 // Execute executes the derived execution
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 	var base64ByteImg []byte
 	for _, input := range inputs {

--- a/pkg/operator/json/v0/operator_test.go
+++ b/pkg/operator/json/v0/operator_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -116,18 +115,16 @@ func TestOperator_Execute(t *testing.T) {
 
 	logger := zap.NewNop()
 	operator := Init(logger, nil)
-	defID := uuid.Must(uuid.NewV4())
-	config := &structpb.Struct{}
 
 	for _, tc := range testcases {
 		c.Run(tc.name, func(c *qt.C) {
-			exec, err := operator.CreateExecution(defID, tc.task, config, logger)
+			exec, err := operator.CreateExecution(nil, tc.task)
 			c.Assert(err, qt.IsNil)
 
 			pbIn, err := structpb.NewStruct(tc.in)
 			c.Assert(err, qt.IsNil)
 
-			got, err := exec.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
 			if tc.wantErr != "" {
 				c.Check(errmsg.Message(err), qt.Matches, tc.wantErr)
 				return
@@ -155,13 +152,12 @@ func TestOperator_CreateExecution(t *testing.T) {
 
 	logger := zap.NewNop()
 	operator := Init(logger, nil)
-	defID := uuid.Must(uuid.NewV4())
 
 	c.Run("nok - unsupported task", func(c *qt.C) {
 		task := "FOOBAR"
 		want := fmt.Sprintf("%s task is not supported.", task)
 
-		_, err := operator.CreateExecution(defID, task, new(structpb.Struct), logger)
+		_, err := operator.CreateExecution(nil, task)
 		c.Check(err, qt.IsNotNil)
 		c.Check(errmsg.Message(err), qt.Equals, want)
 	})

--- a/pkg/operator/start/v0/config/definition.json
+++ b/pkg/operator/start/v0/config/definition.json
@@ -10,7 +10,7 @@
   "public": true,
   "spec": {},
   "title": "Start",
-  "tombstone": false,
+  "tombstone": true,
   "uid": "2ac8be70-0f7a-4b61-a33d-098b8acfa6f3",
   "version": "0.1.0",
   "source_url": "https://github.com/instill-ai/component/blob/main/pkg/operator/start/v0",

--- a/pkg/operator/start/v0/main.go
+++ b/pkg/operator/start/v0/main.go
@@ -2,51 +2,58 @@ package start
 
 import (
 	_ "embed"
+	"fmt"
 	"sync"
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
 )
 
-var (
-	//go:embed config/definition.json
-	definitionJSON []byte
-	//go:embed config/tasks.json
-	tasksJSON []byte
-	once      sync.Once
-	operator  base.IOperator
-)
+//go:embed config/definition.json
+var definitionJSON []byte
 
-type Operator struct {
-	base.Operator
+//go:embed config/tasks.json
+var tasksJSON []byte
+
+var once sync.Once
+var con *operator
+
+type operator struct {
+	base.BaseOperator
 }
 
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseOperatorExecution
 }
 
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IOperator {
+func Init(l *zap.Logger, u base.UsageHandler) *operator {
 	once.Do(func() {
-		operator = &Operator{
-			Operator: base.Operator{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		con = &operator{
+			BaseOperator: base.BaseOperator{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-		err := operator.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
+		err := con.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
+			panic(err)
 		}
 	})
-	return operator
+	return con
 }
 
-func (o *Operator) CreateExecution(defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
-	panic("this is a special pipeline operator, we should not implement this function")
+func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+	}}, nil
 }
 
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
-	panic("this is a special pipeline operator, we should not implement this function")
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+	return nil, fmt.Errorf("the Airbyte operator has been removed")
+}
+
+func (o *operator) Test(sysVars map[string]any, connection *structpb.Struct) error {
+	return fmt.Errorf("the Airbyte operator has been removed")
 }

--- a/pkg/operator/text/v0/convert_test.go
+++ b/pkg/operator/text/v0/convert_test.go
@@ -76,7 +76,7 @@ func TestConvertToText(t *testing.T) {
 				input,
 			}
 
-			e := &Execution{}
+			e := &execution{}
 			e.Task = "TASK_CONVERT_TO_TEXT"
 
 			if outputs, err := e.Execute(inputs); err != nil {

--- a/pkg/operator/text/v0/main.go
+++ b/pkg/operator/text/v0/main.go
@@ -7,7 +7,6 @@ import (
 
 	_ "embed" // embed
 
-	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -25,44 +24,44 @@ var (
 	//go:embed config/tasks.json
 	tasksJSON []byte
 	once      sync.Once
-	operator  base.IOperator
+	op        *operator
 )
 
 // Operator is the derived operator
-type Operator struct {
-	base.Operator
+type operator struct {
+	base.BaseOperator
 }
 
 // Execution is the derived execution
-type Execution struct {
-	base.Execution
+type execution struct {
+	base.BaseOperatorExecution
 }
 
 // Init initializes the operator
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) base.IOperator {
+func Init(l *zap.Logger, u base.UsageHandler) *operator {
 	once.Do(func() {
-		operator = &Operator{
-			Operator: base.Operator{
-				Component: base.Component{Logger: logger, UsageHandler: usageHandler},
+		op = &operator{
+			BaseOperator: base.BaseOperator{
+				Logger:       l,
+				UsageHandler: u,
 			},
 		}
-		err := operator.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
+		err := op.LoadOperatorDefinition(definitionJSON, tasksJSON, nil)
 		if err != nil {
-			logger.Fatal(err.Error())
+			panic(err)
 		}
 	})
-	return operator
+	return op
 }
 
-// CreateExecution creates the derived execution
-func (o *Operator) CreateExecution(defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
-	e := &Execution{}
-	e.Execution = base.CreateExecutionHelper(e, o, defUID, task, config, logger)
-	return e, nil
+func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
+	return &base.ExecutionWrapper{Execution: &execution{
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+	}}, nil
 }
 
 // Execute executes the derived execution
-func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
 	for _, input := range inputs {

--- a/pkg/operator/text/v0/split_test.go
+++ b/pkg/operator/text/v0/split_test.go
@@ -18,7 +18,7 @@ func TestSplitByToken(t *testing.T) {
 		input,
 	}
 
-	e := &Execution{}
+	e := &execution{}
 	e.Task = "TASK_SPLIT_BY_TOKEN"
 
 	if _, err := e.Execute(inputs); err != nil {


### PR DESCRIPTION
Because

- The original interface design was too complex and hard to read.

This commit

- Simplifies the interface structure.