### PR TITLE
feat: adopt system variables

### DIFF
--- a/pkg/base/connector_test.go
+++ b/pkg/base/connector_test.go
@@ -33,7 +33,7 @@ func TestConnector_ListConnectorDefinitions(t *testing.T) {
 		map[string][]byte{"additional.json": connectorAdditionalJSON})
 	c.Assert(err, qt.IsNil)
 
-	got, err := conn.GetConnectorDefinition(nil)
+	got, err := conn.GetConnectorDefinition(nil, nil)
 	c.Assert(err, qt.IsNil)
 	c.Check(wantConnectorDefinitionJSON, qt.JSONEquals, got)
 }

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -15,7 +15,7 @@ type IOperator interface {
 	IComponent
 
 	LoadOperatorDefinition(definitionJSON []byte, tasksJSON []byte, additionalJSONBytes map[string][]byte) error
-	GetOperatorDefinition(component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error)
+	GetOperatorDefinition(sysVars map[string]any, component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error)
 	CreateExecution(sysVars map[string]any, task string) (*ExecutionWrapper, error)
 }
 
@@ -36,8 +36,9 @@ type IOperatorExecution interface {
 }
 
 type BaseOperatorExecution struct {
-	Operator IOperator
-	Task     string
+	Operator        IOperator
+	SystemVariables map[string]any
+	Task            string
 }
 
 func (o *BaseOperator) GetID() string {
@@ -59,7 +60,7 @@ func (o *BaseOperator) GetTaskOutputSchemas() map[string]string {
 	return o.taskOutputSchemas
 }
 
-func (o *BaseOperator) GetOperatorDefinition(component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error) {
+func (o *BaseOperator) GetOperatorDefinition(sysVars map[string]any, component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error) {
 	return o.definition, nil
 }
 
@@ -129,6 +130,9 @@ func (e *BaseOperatorExecution) GetTask() string {
 }
 func (e *BaseOperatorExecution) GetOperator() IOperator {
 	return e.Operator
+}
+func (e *BaseOperatorExecution) GetSystemVariables() map[string]any {
+	return e.SystemVariables
 }
 func (e *BaseOperatorExecution) GetLogger() *zap.Logger {
 	return e.Operator.GetLogger()

--- a/pkg/base/operator_test.go
+++ b/pkg/base/operator_test.go
@@ -28,7 +28,7 @@ func TestOperator_ListOperatorDefinitions(t *testing.T) {
 	err := op.LoadOperatorDefinition(operatorDefJSON, operatorTasksJSON, nil)
 	c.Assert(err, qt.IsNil)
 
-	got, err := op.GetOperatorDefinition(nil)
+	got, err := op.GetOperatorDefinition(nil, nil)
 	c.Assert(err, qt.IsNil)
 	c.Check(wantOperatorDefinitionJSON, qt.JSONEquals, got)
 }

--- a/pkg/base/testdata/wantConnectorDefinition.json
+++ b/pkg/base/testdata/wantConnectorDefinition.json
@@ -6,26 +6,7 @@
   "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/openai",
   "icon": "OpenAI/openai.svg",
   "spec": {
-    "resource_specification": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "instillShortDescription": "",
-      "properties": {
-        "api_key": {
-          "description": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
-          "instillCredentialField": true,
-          "instillShortDescription": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
-          "instillUIOrder": 0,
-          "title": "API Key",
-          "type": "string"
-        }
-      },
-      "required": [
-        "api_key"
-      ],
-      "title": "OpenAI Connector Resource",
-      "type": "object"
-    },
+    "resource_specification": {},
     "component_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "oneOf": [

--- a/pkg/connector/airbyte/v0/main.go
+++ b/pkg/connector/airbyte/v0/main.go
@@ -46,7 +46,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/archetypeai/v0/main.go
+++ b/pkg/connector/archetypeai/v0/main.go
@@ -65,7 +65,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	e := &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 		client:                 newClient(connection, c.Logger),
 	}
 

--- a/pkg/connector/bigquery/v0/main.go
+++ b/pkg/connector/bigquery/v0/main.go
@@ -54,7 +54,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/googlecloudstorage/v0/main.go
+++ b/pkg/connector/googlecloudstorage/v0/main.go
@@ -53,7 +53,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/googlesearch/v0/main.go
+++ b/pkg/connector/googlesearch/v0/main.go
@@ -55,7 +55,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/huggingface/v0/main.go
+++ b/pkg/connector/huggingface/v0/main.go
@@ -72,7 +72,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/instill/v0/image_classification.go
+++ b/pkg/connector/instill/v0/image_classification.go
@@ -47,7 +47,7 @@ func (e *execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/image_to_image.go
+++ b/pkg/connector/instill/v0/image_to_image.go
@@ -65,7 +65,7 @@ func (e *execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/instance_segmentation.go
+++ b/pkg/connector/instill/v0/instance_segmentation.go
@@ -45,7 +45,7 @@ func (e *execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/keypoint_detection.go
+++ b/pkg/connector/instill/v0/keypoint_detection.go
@@ -41,7 +41,7 @@ func (e *execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/object_detection.go
+++ b/pkg/connector/instill/v0/object_detection.go
@@ -48,7 +48,7 @@ func (e *execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 		TaskInputs: taskInputs,
 	}
 
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/ocr.go
+++ b/pkg/connector/instill/v0/ocr.go
@@ -41,7 +41,7 @@ func (e *execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/semantic_segmentation.go
+++ b/pkg/connector/instill/v0/semantic_segmentation.go
@@ -45,7 +45,7 @@ func (e *execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+	ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err

--- a/pkg/connector/instill/v0/text_generation.go
+++ b/pkg/connector/instill/v0/text_generation.go
@@ -44,7 +44,7 @@ func (e *execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/text_generation_chat.go
+++ b/pkg/connector/instill/v0/text_generation_chat.go
@@ -44,7 +44,7 @@ func (e *execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/text_to_image.go
+++ b/pkg/connector/instill/v0/text_to_image.go
@@ -56,7 +56,7 @@ func (e *execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/instill/v0/visual_question_answering.go
+++ b/pkg/connector/instill/v0/visual_question_answering.go
@@ -44,7 +44,7 @@ func (e *execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.Connection))
+		ctx := metadata.NewOutgoingContext(context.Background(), getRequestMetadata(e.SystemVariables, e.Connection))
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err

--- a/pkg/connector/main.go
+++ b/pkg/connector/main.go
@@ -82,17 +82,17 @@ func (cs *ConnectorStore) CreateExecution(defUID uuid.UUID, sysVars map[string]a
 	return nil, fmt.Errorf("connector definition not found")
 }
 
-func (cs *ConnectorStore) GetConnectorDefinitionByUID(defUID uuid.UUID, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
+func (cs *ConnectorStore) GetConnectorDefinitionByUID(defUID uuid.UUID, sysVars map[string]any, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
 	if con, ok := cs.connectorUIDMap[defUID]; ok {
-		return con.con.GetConnectorDefinition(component)
+		return con.con.GetConnectorDefinition(sysVars, component)
 	}
 	return nil, fmt.Errorf("connector definition not found")
 }
 
 // Get the operator definition by definition id
-func (cs *ConnectorStore) GetConnectorDefinitionByID(defID string, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
+func (cs *ConnectorStore) GetConnectorDefinitionByID(defID string, sysVars map[string]any, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
 	if con, ok := cs.connectorIDMap[defID]; ok {
-		return con.con.GetConnectorDefinition(component)
+		return con.con.GetConnectorDefinition(sysVars, component)
 	}
 	return nil, fmt.Errorf("connector definition not found")
 }
@@ -101,7 +101,7 @@ func (cs *ConnectorStore) GetConnectorDefinitionByID(defID string, component *pi
 func (cs *ConnectorStore) ListConnectorDefinitions(returnTombstone bool) []*pipelinePB.ConnectorDefinition {
 	defs := []*pipelinePB.ConnectorDefinition{}
 	for _, con := range cs.connectorUIDMap {
-		def, err := con.con.GetConnectorDefinition(nil)
+		def, err := con.con.GetConnectorDefinition(nil, nil)
 		if err == nil {
 			if !def.Tombstone || returnTombstone {
 				defs = append(defs, def)

--- a/pkg/connector/openai/v0/main.go
+++ b/pkg/connector/openai/v0/main.go
@@ -63,7 +63,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/pinecone/v0/main.go
+++ b/pkg/connector/pinecone/v0/main.go
@@ -55,7 +55,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/redis/v0/main.go
+++ b/pkg/connector/redis/v0/main.go
@@ -54,7 +54,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/restapi/v0/main.go
+++ b/pkg/connector/restapi/v0/main.go
@@ -74,7 +74,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 
@@ -171,8 +171,8 @@ func (c *connector) Test(sysVars map[string]any, connection *structpb.Struct) er
 }
 
 // Generate the model_name enum based on the task
-func (c *connector) GetConnectorDefinition(component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
-	oriDef, err := c.BaseConnector.GetConnectorDefinition(nil)
+func (c *connector) GetConnectorDefinition(sysVars map[string]any, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
+	oriDef, err := c.BaseConnector.GetConnectorDefinition(nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/stabilityai/v0/main.go
+++ b/pkg/connector/stabilityai/v0/main.go
@@ -55,7 +55,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/connector/website/v0/main.go
+++ b/pkg/connector/website/v0/main.go
@@ -51,7 +51,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *connector {
 
 func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, Connection: connection, Task: task},
+		BaseConnectorExecution: base.BaseConnectorExecution{Connector: c, SystemVariables: sysVars, Connection: connection, Task: task},
 	}}, nil
 }
 

--- a/pkg/operator/base64/v0/main.go
+++ b/pkg/operator/base64/v0/main.go
@@ -59,7 +59,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *operator {
 
 func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, SystemVariables: sysVars, Task: task},
 	}}, nil
 }
 

--- a/pkg/operator/end/v0/main.go
+++ b/pkg/operator/end/v0/main.go
@@ -46,7 +46,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *operator {
 
 func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, SystemVariables: sysVars, Task: task},
 	}}, nil
 }
 

--- a/pkg/operator/image/v0/main.go
+++ b/pkg/operator/image/v0/main.go
@@ -57,7 +57,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *operator {
 
 func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, SystemVariables: sysVars, Task: task},
 	}}, nil
 }
 

--- a/pkg/operator/json/v0/main.go
+++ b/pkg/operator/json/v0/main.go
@@ -61,7 +61,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *operator {
 
 func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
 	e := &execution{
-		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, SystemVariables: sysVars, Task: task},
 	}
 
 	switch task {

--- a/pkg/operator/main.go
+++ b/pkg/operator/main.go
@@ -65,18 +65,17 @@ func (os *OperatorStore) CreateExecution(defUID uuid.UUID, sysVars map[string]an
 	return nil, fmt.Errorf("operator definition not found")
 }
 
-func (os *OperatorStore) GetOperatorDefinitionByUID(defUID uuid.UUID, component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error) {
-	fmt.Println("defUID", defUID)
+func (os *OperatorStore) GetOperatorDefinitionByUID(defUID uuid.UUID, sysVars map[string]any, component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error) {
 	if op, ok := os.operatorUIDMap[defUID]; ok {
-		return op.op.GetOperatorDefinition(component)
+		return op.op.GetOperatorDefinition(sysVars, component)
 	}
 	return nil, fmt.Errorf("operator definition not found")
 }
 
 // Get the operator definition by definition id
-func (os *OperatorStore) GetOperatorDefinitionByID(defID string, component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error) {
+func (os *OperatorStore) GetOperatorDefinitionByID(defID string, sysVars map[string]any, component *pipelinePB.OperatorComponent) (*pipelinePB.OperatorDefinition, error) {
 	if op, ok := os.operatorIDMap[defID]; ok {
-		return op.op.GetOperatorDefinition(component)
+		return op.op.GetOperatorDefinition(sysVars, component)
 	}
 	return nil, fmt.Errorf("operator definition not found")
 }
@@ -85,7 +84,7 @@ func (os *OperatorStore) GetOperatorDefinitionByID(defID string, component *pipe
 func (os *OperatorStore) ListOperatorDefinitions(returnTombstone bool) []*pipelinePB.OperatorDefinition {
 	defs := []*pipelinePB.OperatorDefinition{}
 	for _, op := range os.operatorUIDMap {
-		def, err := op.op.GetOperatorDefinition(nil)
+		def, err := op.op.GetOperatorDefinition(nil, nil)
 		if err == nil {
 			if !def.Tombstone || returnTombstone {
 				defs = append(defs, def)

--- a/pkg/operator/start/v0/main.go
+++ b/pkg/operator/start/v0/main.go
@@ -46,7 +46,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *operator {
 
 func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, SystemVariables: sysVars, Task: task},
 	}}, nil
 }
 

--- a/pkg/operator/text/v0/main.go
+++ b/pkg/operator/text/v0/main.go
@@ -56,7 +56,7 @@ func Init(l *zap.Logger, u base.UsageHandler) *operator {
 
 func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
 	return &base.ExecutionWrapper{Execution: &execution{
-		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, Task: task},
+		BaseOperatorExecution: base.BaseOperatorExecution{Operator: o, SystemVariables: sysVars, Task: task},
 	}}, nil
 }
 


### PR DESCRIPTION
Because

- Some connectors or operators require data from system variables instead of user input, we treat this kind of data as system variables.

This commit
- Adopts system variables.