### PR TITLE
chore: add instillAcceptFormats in connection JSON schema

### DIFF
--- a/pkg/connector/archetypeai/v0/config/definition.json
+++ b/pkg/connector/archetypeai/v0/config/definition.json
@@ -17,6 +17,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Archetype AI API key",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "title": "API Key",

--- a/pkg/connector/bigquery/v0/config/definition.json
+++ b/pkg/connector/bigquery/v0/config/definition.json
@@ -15,12 +15,18 @@
       "properties": {
         "dataset_id": {
           "description": "Fill in your BigQuery Dataset ID.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillUIOrder": 2,
           "title": "BigQuery Dataset ID",
           "type": "string"
         },
         "json_key": {
           "description": "Contents of the JSON key file with access to the bucket.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "instillUIMultiline": true,
@@ -29,12 +35,18 @@
         },
         "project_id": {
           "description": "Fill in your BigQuery Project ID.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillUIOrder": 1,
           "title": "BigQuery Project ID",
           "type": "string"
         },
         "table_name": {
           "description": "Fill in your BigQuery Table Name.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillUIOrder": 3,
           "title": "BigQuery Table Name",
           "type": "string"

--- a/pkg/connector/googlecloudstorage/v0/config/definition.json
+++ b/pkg/connector/googlecloudstorage/v0/config/definition.json
@@ -15,6 +15,9 @@
       "properties": {
         "bucket_name": {
           "description": "Name of the bucket to be used for object storage.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": false,
           "instillUIOrder": 0,
           "title": "Bucket Name",
@@ -22,6 +25,9 @@
         },
         "json_key": {
           "description": "Contents of the JSON key file with access to the bucket.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 1,
           "instillUIMultiline": true,

--- a/pkg/connector/googlesearch/v0/config/tasks.json
+++ b/pkg/connector/googlesearch/v0/config/tasks.json
@@ -4,6 +4,9 @@
       "properties": {
         "link": {
           "description": "The full URL to which the search result is pointing, e.g., http://www.example.com/foo/bar.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillFormat": "string",
           "instillUIOrder": 1,
           "title": "Link",
@@ -11,6 +14,9 @@
         },
         "link_html": {
           "description": "The scraped raw html of the link associated with this search result",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillFormat": "string",
           "instillUIMultiline": true,
           "instillUIOrder": 4,
@@ -19,6 +25,9 @@
         },
         "link_text": {
           "description": "The scraped text of the link associated with this search result, in plain text",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillFormat": "string",
           "instillUIMultiline": true,
           "instillUIOrder": 3,
@@ -27,6 +36,9 @@
         },
         "snippet": {
           "description": "The snippet from the page associated with this search result, in plain text",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillFormat": "string",
           "instillUIMultiline": true,
           "instillUIOrder": 2,
@@ -35,6 +47,9 @@
         },
         "title": {
           "description": "The title of a search result, in plain text",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillFormat": "string",
           "instillUIMultiline": true,
           "instillUIOrder": 0,

--- a/pkg/connector/huggingface/v0/config/definition.json
+++ b/pkg/connector/huggingface/v0/config/definition.json
@@ -31,6 +31,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Hugging face API token. To find your token, visit https://huggingface.co/settings/tokens.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "title": "API Key",
@@ -39,6 +42,9 @@
         "base_url": {
           "default": "https://api-inference.huggingface.co",
           "description": "Hostname for the endpoint. To use Inference API set to https://api-inference.huggingface.co, for Inference Endpoint set to your custom endpoint.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": false,
           "instillUIOrder": 1,
           "title": "Base URL",
@@ -47,6 +53,9 @@
         "is_custom_endpoint": {
           "default": false,
           "description": "Fill true if you are using a custom Inference Endpoint and not the Inference API.",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
           "instillCredentialField": false,
           "instillUIOrder": 2,
           "title": "Is Custom Endpoint",

--- a/pkg/connector/instill/v0/config/definition.json
+++ b/pkg/connector/instill/v0/config/definition.json
@@ -36,6 +36,9 @@
           "properties": {
             "api_token": {
               "description": "To access models on Instill Core/Cloud, enter your Instill Core/Cloud API Token. You can find your tokens by visiting your Console's Settings > API Tokens page.",
+              "instillAcceptFormats": [
+                "string"
+              ],
               "instillCredentialField": true,
               "instillUIOrder": 0,
               "title": "API Token",
@@ -47,6 +50,9 @@
             "server_url": {
               "default": "https://api.instill.tech",
               "description": "Base URL for the Instill Cloud API. To access models on Instill Cloud, use the base URL `https://api.instill.tech`. To access models on your local Instill Core, use the base URL `http://api-gateway:8080`.",
+              "instillAcceptFormats": [
+                "string"
+              ],
               "instillUIOrder": 1,
               "title": "Server URL",
               "type": "string"

--- a/pkg/connector/numbers/v0/config/definition.json
+++ b/pkg/connector/numbers/v0/config/definition.json
@@ -15,6 +15,9 @@
       "properties": {
         "capture_token": {
           "description": "Fill your Capture token in the Capture App. To access your tokens, you need a Capture App account and you can sign in with email or wallet to acquire the Capture Token.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "title": "Capture token",

--- a/pkg/connector/openai/v0/config/definition.json
+++ b/pkg/connector/openai/v0/config/definition.json
@@ -19,6 +19,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "title": "API Key",
@@ -26,6 +29,9 @@
         },
         "organization": {
           "description": "Specify which organization is used for the requests. Usage will count against the specified organization's subscription quota.",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillUIOrder": 1,
           "title": "Organization ID",
           "type": "string"

--- a/pkg/connector/pinecone/v0/config/definition.json
+++ b/pkg/connector/pinecone/v0/config/definition.json
@@ -16,6 +16,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Pinecone AI API key. You can create a api key in [Pinecone Console](https://app.pinecone.io/)",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "title": "API Key",
@@ -23,6 +26,9 @@
         },
         "url": {
           "description": "Fill in your Pinecone base URL. It is in the form [https://index_name-project_id.svc.environment.pinecone.io]",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": false,
           "instillUIOrder": 1,
           "title": "Pinecone Base URL",

--- a/pkg/connector/redis/v0/config/definition.json
+++ b/pkg/connector/redis/v0/config/definition.json
@@ -21,6 +21,9 @@
           "examples": [
             "localhost,127.0.0.1"
           ],
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": false,
           "instillUIOrder": 0,
           "title": "Host",
@@ -28,6 +31,9 @@
         },
         "password": {
           "description": "Password associated with Redis",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 3,
           "title": "Password",
@@ -36,6 +42,9 @@
         "port": {
           "default": 6379,
           "description": "Port of Redis",
+          "instillAcceptFormats": [
+            "integer"
+          ],
           "instillUIOrder": 1,
           "maximum": 65536,
           "minimum": 0,
@@ -45,6 +54,9 @@
         "ssl": {
           "default": false,
           "description": "Indicates whether SSL encryption protocol will be used to connect to Redis. It is recommended to use SSL connection if possible.",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
           "instillUIOrder": 4,
           "title": "SSL Connection",
           "type": "boolean"
@@ -81,6 +93,9 @@
               "properties": {
                 "ca_cert": {
                   "description": "CA certificate to use for SSL connection",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillCredentialField": true,
                   "instillUIOrder": 1,
                   "multiline": true,
@@ -90,6 +105,9 @@
                 },
                 "client_cert": {
                   "description": "Client certificate to use for SSL connection",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillCredentialField": true,
                   "instillUIOrder": 2,
                   "multiline": true,
@@ -99,6 +117,9 @@
                 },
                 "client_key": {
                   "description": "Client key to use for SSL connection",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillCredentialField": true,
                   "instillUIOrder": 3,
                   "multiline": true,
@@ -136,6 +157,9 @@
         },
         "username": {
           "description": "Username associated with Redis",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillUIOrder": 2,
           "title": "Username",
           "type": "string"

--- a/pkg/connector/restapi/v0/config/definition.json
+++ b/pkg/connector/restapi/v0/config/definition.json
@@ -49,6 +49,9 @@
                 },
                 "password": {
                   "description": "Password for Basic auth",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillCredentialField": true,
                   "instillUIOrder": 2,
                   "order": 2,
@@ -57,6 +60,9 @@
                 },
                 "username": {
                   "description": "Username for Basic Auth",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillUIOrder": 1,
                   "order": 1,
                   "title": "Username",
@@ -79,6 +85,9 @@
                     "header",
                     "query"
                   ],
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillUIOrder": 3,
                   "order": 3,
                   "title": "Where to Add API Key to",
@@ -94,6 +103,9 @@
                 "key": {
                   "default": "X-API-Key",
                   "description": "Key name for API key authentication",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillUIOrder": 1,
                   "order": 1,
                   "title": "Key Name",
@@ -101,6 +113,9 @@
                 },
                 "value": {
                   "description": "Key value for API key authentication",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillCredentialField": true,
                   "instillUIOrder": 2,
                   "order": 2,
@@ -127,6 +142,9 @@
                 },
                 "token": {
                   "description": "Bearer token",
+                  "instillAcceptFormats": [
+                    "string"
+                  ],
                   "instillCredentialField": true,
                   "instillUIOrder": 1,
                   "order": 1,

--- a/pkg/connector/stabilityai/v0/config/definition.json
+++ b/pkg/connector/stabilityai/v0/config/definition.json
@@ -16,6 +16,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Stability AI API key. To find your keys, visit - https://platform.stability.ai/account/keys",
+          "instillAcceptFormats": [
+            "string"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "title": "API Key",


### PR DESCRIPTION
Because

- We need to include `instillAcceptFormats` in the JSON schema for the Console's auto-form to function correctly.

This commit

- Adds instillAcceptFormats in connection JSON schema.

