### PR TITLE
chore: add instillUpstreamTypes in connection JSON schema

### DIFF
--- a/pkg/connector/archetypeai/v0/config/definition.json
+++ b/pkg/connector/archetypeai/v0/config/definition.json
@@ -17,6 +17,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Archetype AI API key",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/connector/bigquery/v0/config/definition.json
+++ b/pkg/connector/bigquery/v0/config/definition.json
@@ -15,6 +15,9 @@
       "properties": {
         "dataset_id": {
           "description": "Fill in your BigQuery Dataset ID.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -24,6 +27,9 @@
         },
         "json_key": {
           "description": "Contents of the JSON key file with access to the bucket.",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -35,6 +41,9 @@
         },
         "project_id": {
           "description": "Fill in your BigQuery Project ID.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -44,6 +53,9 @@
         },
         "table_name": {
           "description": "Fill in your BigQuery Table Name.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/connector/googlecloudstorage/v0/config/definition.json
+++ b/pkg/connector/googlecloudstorage/v0/config/definition.json
@@ -15,6 +15,9 @@
       "properties": {
         "bucket_name": {
           "description": "Name of the bucket to be used for object storage.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -25,6 +28,9 @@
         },
         "json_key": {
           "description": "Contents of the JSON key file with access to the bucket.",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/connector/googlesearch/v0/config/definition.json
+++ b/pkg/connector/googlesearch/v0/config/definition.json
@@ -15,6 +15,9 @@
       "properties": {
         "api_key": {
           "description": "API Key for the Google Custom Search API. You can create one here: https://developers.google.com/custom-search/v1/overview#api_key",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillCredentialField": true,
           "instillUIOrder": 0,
           "title": "API Key",
@@ -22,6 +25,9 @@
         },
         "cse_id": {
           "description": "ID of the Search Engine to use. Before using the Custom Search JSON API you will first need to create and configure your Programmable Search Engine. If you have not already created a Programmable Search Engine, you can start by visiting the Programmable Search Engine control panel https://programmablesearchengine.google.com/controlpanel/all. You can find this in the URL of your Search Engine. For example, if the URL of your search engine is https://cse.google.com/cse.js?cx=012345678910, the ID value is: 012345678910",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillCredentialField": false,
           "instillUIOrder": 1,
           "title": "Search Engine ID",

--- a/pkg/connector/huggingface/v0/config/definition.json
+++ b/pkg/connector/huggingface/v0/config/definition.json
@@ -31,6 +31,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Hugging face API token. To find your token, visit https://huggingface.co/settings/tokens.",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -42,6 +45,9 @@
         "base_url": {
           "default": "https://api-inference.huggingface.co",
           "description": "Hostname for the endpoint. To use Inference API set to https://api-inference.huggingface.co, for Inference Endpoint set to your custom endpoint.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -53,6 +59,9 @@
         "is_custom_endpoint": {
           "default": false,
           "description": "Fill true if you are using a custom Inference Endpoint and not the Inference API.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "boolean"
           ],

--- a/pkg/connector/instill/v0/config/definition.json
+++ b/pkg/connector/instill/v0/config/definition.json
@@ -36,6 +36,9 @@
           "properties": {
             "api_token": {
               "description": "To access models on Instill Core/Cloud, enter your Instill Core/Cloud API Token. You can find your tokens by visiting your Console's Settings > API Tokens page.",
+              "instillUpstreamTypes": [
+                "reference"
+              ],
               "instillAcceptFormats": [
                 "string"
               ],
@@ -50,6 +53,9 @@
             "server_url": {
               "default": "https://api.instill.tech",
               "description": "Base URL for the Instill Cloud API. To access models on Instill Cloud, use the base URL `https://api.instill.tech`. To access models on your local Instill Core, use the base URL `http://api-gateway:8080`.",
+              "instillUpstreamTypes": [
+                "value"
+              ],
               "instillAcceptFormats": [
                 "string"
               ],

--- a/pkg/connector/numbers/v0/config/definition.json
+++ b/pkg/connector/numbers/v0/config/definition.json
@@ -15,6 +15,9 @@
       "properties": {
         "capture_token": {
           "description": "Fill your Capture token in the Capture App. To access your tokens, you need a Capture App account and you can sign in with email or wallet to acquire the Capture Token.",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/connector/openai/v0/config/definition.json
+++ b/pkg/connector/openai/v0/config/definition.json
@@ -19,6 +19,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -29,6 +32,9 @@
         },
         "organization": {
           "description": "Specify which organization is used for the requests. Usage will count against the specified organization's subscription quota.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/connector/pinecone/v0/config/definition.json
+++ b/pkg/connector/pinecone/v0/config/definition.json
@@ -16,6 +16,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Pinecone AI API key. You can create a api key in [Pinecone Console](https://app.pinecone.io/)",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -26,6 +29,9 @@
         },
         "url": {
           "description": "Fill in your Pinecone base URL. It is in the form [https://index_name-project_id.svc.environment.pinecone.io]",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/connector/redis/v0/config/definition.json
+++ b/pkg/connector/redis/v0/config/definition.json
@@ -21,6 +21,9 @@
           "examples": [
             "localhost,127.0.0.1"
           ],
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -31,6 +34,9 @@
         },
         "password": {
           "description": "Password associated with Redis",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],
@@ -42,6 +48,9 @@
         "port": {
           "default": 6379,
           "description": "Port of Redis",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "integer"
           ],
@@ -54,6 +63,9 @@
         "ssl": {
           "default": false,
           "description": "Indicates whether SSL encryption protocol will be used to connect to Redis. It is recommended to use SSL connection if possible.",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "boolean"
           ],
@@ -93,6 +105,9 @@
               "properties": {
                 "ca_cert": {
                   "description": "CA certificate to use for SSL connection",
+                  "instillUpstreamTypes": [
+                    "reference"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -105,6 +120,9 @@
                 },
                 "client_cert": {
                   "description": "Client certificate to use for SSL connection",
+                  "instillUpstreamTypes": [
+                    "reference"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -117,6 +135,9 @@
                 },
                 "client_key": {
                   "description": "Client key to use for SSL connection",
+                  "instillUpstreamTypes": [
+                    "reference"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -157,6 +178,9 @@
         },
         "username": {
           "description": "Username associated with Redis",
+          "instillUpstreamTypes": [
+            "value"
+          ],
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/connector/restapi/v0/config/definition.json
+++ b/pkg/connector/restapi/v0/config/definition.json
@@ -49,6 +49,9 @@
                 },
                 "password": {
                   "description": "Password for Basic auth",
+                  "instillUpstreamTypes": [
+                    "reference"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -60,6 +63,9 @@
                 },
                 "username": {
                   "description": "Username for Basic Auth",
+                  "instillUpstreamTypes": [
+                    "value"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -85,6 +91,9 @@
                     "header",
                     "query"
                   ],
+                  "instillUpstreamTypes": [
+                    "value"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -103,6 +112,9 @@
                 "key": {
                   "default": "X-API-Key",
                   "description": "Key name for API key authentication",
+                  "instillUpstreamTypes": [
+                    "value"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -113,6 +125,9 @@
                 },
                 "value": {
                   "description": "Key value for API key authentication",
+                  "instillUpstreamTypes": [
+                    "reference"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],
@@ -142,6 +157,9 @@
                 },
                 "token": {
                   "description": "Bearer token",
+                  "instillUpstreamTypes": [
+                    "reference"
+                  ],
                   "instillAcceptFormats": [
                     "string"
                   ],

--- a/pkg/connector/stabilityai/v0/config/definition.json
+++ b/pkg/connector/stabilityai/v0/config/definition.json
@@ -16,6 +16,9 @@
       "properties": {
         "api_key": {
           "description": "Fill your Stability AI API key. To find your keys, visit - https://platform.stability.ai/account/keys",
+          "instillUpstreamTypes": [
+            "reference"
+          ],
           "instillAcceptFormats": [
             "string"
           ],


### PR DESCRIPTION
Because

- We need to include `instillUpstreamTypes` in the JSON schema for the Console's auto-form to function correctly.

This commit

- Adds `instillUpstreamTypes` in connection JSON schema.

