### PR TITLE
chore: the ListOperatorDefinitions and ListConnectorDefinitions should be ordered

### DIFF
--- a/pkg/connector/main.go
+++ b/pkg/connector/main.go
@@ -33,6 +33,7 @@ var (
 )
 
 type ConnectorStore struct {
+	connectorUIDs   []uuid.UUID
 	connectorUIDMap map[uuid.UUID]*connector
 	connectorIDMap  map[string]*connector
 }
@@ -73,6 +74,7 @@ func (cs *ConnectorStore) Import(con base.IConnector) {
 	c := &connector{con: con}
 	cs.connectorUIDMap[con.GetUID()] = c
 	cs.connectorIDMap[con.GetID()] = c
+	cs.connectorUIDs = append(cs.connectorUIDs, con.GetUID())
 }
 
 func (cs *ConnectorStore) CreateExecution(defUID uuid.UUID, sysVars map[string]any, connection *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
@@ -100,7 +102,8 @@ func (cs *ConnectorStore) GetConnectorDefinitionByID(defID string, sysVars map[s
 // Get the list of connector definitions under this connector
 func (cs *ConnectorStore) ListConnectorDefinitions(returnTombstone bool) []*pipelinePB.ConnectorDefinition {
 	defs := []*pipelinePB.ConnectorDefinition{}
-	for _, con := range cs.connectorUIDMap {
+	for _, uid := range cs.connectorUIDs {
+		con := cs.connectorUIDMap[uid]
 		def, err := con.con.GetConnectorDefinition(nil, nil)
 		if err == nil {
 			if !def.Tombstone || returnTombstone {

--- a/pkg/operator/main.go
+++ b/pkg/operator/main.go
@@ -25,6 +25,7 @@ var (
 
 // Operator is the derived operator
 type OperatorStore struct {
+	operatorUIDs   []uuid.UUID
 	operatorUIDMap map[uuid.UUID]*operator
 	operatorIDMap  map[string]*operator
 }
@@ -56,6 +57,7 @@ func (os *OperatorStore) Import(op base.IOperator) {
 	o := &operator{op: op}
 	os.operatorUIDMap[op.GetUID()] = o
 	os.operatorIDMap[op.GetID()] = o
+	os.operatorUIDs = append(os.operatorUIDs, op.GetUID())
 }
 
 func (os *OperatorStore) CreateExecution(defUID uuid.UUID, sysVars map[string]any, task string) (*base.ExecutionWrapper, error) {
@@ -83,7 +85,8 @@ func (os *OperatorStore) GetOperatorDefinitionByID(defID string, sysVars map[str
 // Get the list of operator definitions under this operator
 func (os *OperatorStore) ListOperatorDefinitions(returnTombstone bool) []*pipelinePB.OperatorDefinition {
 	defs := []*pipelinePB.OperatorDefinition{}
-	for _, op := range os.operatorUIDMap {
+	for _, uid := range os.operatorUIDs {
+		op := os.operatorUIDMap[uid]
 		def, err := op.op.GetOperatorDefinition(nil, nil)
 		if err == nil {
 			if !def.Tombstone || returnTombstone {


### PR DESCRIPTION
Because

- The `ListOperatorDefinitions` and `ListConnectorDefinitions` data should was not ordered.

This commit

- Fix the bug.
