### PR TITLE
chore(openai): add missing title

### DIFF
--- a/pkg/connector/openai/v0/config/tasks.json
+++ b/pkg/connector/openai/v0/config/tasks.json
@@ -311,6 +311,7 @@
               "instillAcceptFormats": [
                 "string"
               ],
+              "title": "Type",
               "example": "text",
               "instillShortDescription": "Setting to `json_object` enables JSON mode. ",
               "instillUIOrder": 0,


### PR DESCRIPTION
Because

- A title in OpenAI connector JSON schema was missing.

This commit

- Adds missing title.
