### PR TITLE
refactor: expose `RenderJSON()` and rename `resource_specification`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240415145600-50085798159d
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/itchyny/gojq v0.12.14
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240415145600-50085798159d h1:o8vynHQD3PG0b9VU6sw/9RUfOotxEcFnl9AjIhnPTWA=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240415145600-50085798159d/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884 h1:FfNGEn+USpO8z+/fOA6+WGcOSaOw2SQcR+ovyAUC03A=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=
 github.com/instill-ai/x v0.4.0-alpha/go.mod h1:L6jmDPrUou6XskaLXZuK/gDeitdoPa9yE8ONKt1ZwCw=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=

--- a/pkg/base/component.go
+++ b/pkg/base/component.go
@@ -452,7 +452,7 @@ func ConvertToStructpb(from interface{}) (*structpb.Struct, error) {
 	return to, nil
 }
 
-func renderTaskJSON(tasksJSONBytes []byte, additionalJSONBytes map[string][]byte) ([]byte, error) {
+func RenderJSON(tasksJSONBytes []byte, additionalJSONBytes map[string][]byte) ([]byte, error) {
 	var err error
 	mp := provider.NewMap()
 	for k, v := range additionalJSONBytes {

--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -88,7 +88,7 @@ func (c *BaseConnector) LoadConnectorDefinition(definitionJSONBytes []byte, task
 	if err != nil {
 		return err
 	}
-	renderedTasksJSON, nil := renderTaskJSON(tasksJSONBytes, additionalJSONBytes)
+	renderedTasksJSON, nil := RenderJSON(tasksJSONBytes, additionalJSONBytes)
 	if err != nil {
 		return nil
 	}
@@ -133,12 +133,20 @@ func (c *BaseConnector) LoadConnectorDefinition(definitionJSONBytes []byte, task
 		return err
 	}
 
-	connection, err := c.refineResourceSpec(c.definition.Spec.ResourceSpecification)
+	b, err := protojson.Marshal(c.definition.Spec)
 	if err != nil {
 		return err
 	}
-	// deprecated, will be removed soon
-	c.definition.Spec.ResourceSpecification = &structpb.Struct{}
+	connectionSpecification := &structpb.Struct{}
+	err = protojson.Unmarshal(b, connectionSpecification)
+	if err != nil {
+		return err
+	}
+
+	connection, err := c.refineResourceSpec(connectionSpecification)
+	if err != nil {
+		return err
+	}
 
 	connectionPropStruct := &structpb.Struct{Fields: map[string]*structpb.Value{}}
 	connectionPropStruct.Fields["connection"] = structpb.NewStructValue(connection)

--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -133,17 +133,12 @@ func (c *BaseConnector) LoadConnectorDefinition(definitionJSONBytes []byte, task
 		return err
 	}
 
-	b, err := protojson.Marshal(c.definition.Spec)
+	raw := &structpb.Struct{}
+	err = protojson.Unmarshal(definitionJSONBytes, raw)
 	if err != nil {
 		return err
 	}
-	connectionSpecification := &structpb.Struct{}
-	err = protojson.Unmarshal(b, connectionSpecification)
-	if err != nil {
-		return err
-	}
-
-	connection, err := c.refineResourceSpec(connectionSpecification)
+	connection, err := c.refineResourceSpec(raw.Fields["spec"].GetStructValue().Fields["connection_specification"].GetStructValue())
 	if err != nil {
 		return err
 	}

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -73,7 +73,7 @@ func (o *BaseOperator) LoadOperatorDefinition(definitionJSONBytes []byte, tasksJ
 	if err != nil {
 		return err
 	}
-	renderedTasksJSON, nil := renderTaskJSON(tasksJSONBytes, additionalJSONBytes)
+	renderedTasksJSON, nil := RenderJSON(tasksJSONBytes, additionalJSONBytes)
 	if err != nil {
 		return nil
 	}

--- a/pkg/base/testdata/connectorDef.json
+++ b/pkg/base/testdata/connectorDef.json
@@ -10,7 +10,7 @@
   "id": "openai",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
       "properties": {

--- a/pkg/base/testdata/wantConnectorDefinition.json
+++ b/pkg/base/testdata/wantConnectorDefinition.json
@@ -6,7 +6,7 @@
   "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/openai",
   "icon": "OpenAI/openai.svg",
   "spec": {
-    "resource_specification": {},
+    "connection_specification": {},
     "component_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "oneOf": [

--- a/pkg/base/testdata/wantConnectorDefinition.json
+++ b/pkg/base/testdata/wantConnectorDefinition.json
@@ -6,7 +6,6 @@
   "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/openai",
   "icon": "OpenAI/openai.svg",
   "spec": {
-    "connection_specification": {},
     "component_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "oneOf": [

--- a/pkg/connector/airbyte/v0/config/definition.json
+++ b/pkg/connector/airbyte/v0/config/definition.json
@@ -9,7 +9,7 @@
   "version": "0.1.0",
   "release_stage": "RELEASE_STAGE_ALPHA",
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Destination",
       "type": "object"

--- a/pkg/connector/archetypeai/v0/config/definition.json
+++ b/pkg/connector/archetypeai/v0/config/definition.json
@@ -11,7 +11,7 @@
   "id": "archetype-ai",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/bigquery/v0/config/definition.json
+++ b/pkg/connector/bigquery/v0/config/definition.json
@@ -9,7 +9,7 @@
   "id": "bigquery",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/googlecloudstorage/v0/config/definition.json
+++ b/pkg/connector/googlecloudstorage/v0/config/definition.json
@@ -9,7 +9,7 @@
   "id": "gcs",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/googlesearch/v0/config/definition.json
+++ b/pkg/connector/googlesearch/v0/config/definition.json
@@ -9,7 +9,7 @@
   "id": "google-search",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/huggingface/v0/config/definition.json
+++ b/pkg/connector/huggingface/v0/config/definition.json
@@ -25,7 +25,7 @@
   "id": "hugging-face",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
       "properties": {

--- a/pkg/connector/instill/v0/config/definition.json
+++ b/pkg/connector/instill/v0/config/definition.json
@@ -19,7 +19,7 @@
   "id": "instill-model",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
       "oneOf": [

--- a/pkg/connector/numbers/v0/config/definition.json
+++ b/pkg/connector/numbers/v0/config/definition.json
@@ -9,7 +9,7 @@
   "id": "numbers",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/openai/v0/config/definition.json
+++ b/pkg/connector/openai/v0/config/definition.json
@@ -13,7 +13,7 @@
   "id": "openai",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
       "properties": {

--- a/pkg/connector/pinecone/v0/config/definition.json
+++ b/pkg/connector/pinecone/v0/config/definition.json
@@ -10,7 +10,7 @@
   "id": "pinecone",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/redis/v0/config/definition.json
+++ b/pkg/connector/redis/v0/config/definition.json
@@ -11,7 +11,7 @@
   "id": "redis",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
       "properties": {

--- a/pkg/connector/restapi/v0/config/definition.json
+++ b/pkg/connector/restapi/v0/config/definition.json
@@ -15,7 +15,7 @@
   "id": "restapi",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/stabilityai/v0/config/definition.json
+++ b/pkg/connector/stabilityai/v0/config/definition.json
@@ -10,7 +10,7 @@
   "id": "stability-ai",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {

--- a/pkg/connector/website/v0/config/definition.json
+++ b/pkg/connector/website/v0/config/definition.json
@@ -9,7 +9,7 @@
   "id": "website",
   "public": true,
   "spec": {
-    "resource_specification": {
+    "connection_specification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
       "properties": {},


### PR DESCRIPTION
Because

- We've retired connector resource and merge its configuration into component configuration.
- We'd like to expose the `RenderJSON()` function for further usage.

This commit

- Renames `resource_specification` to `connection_specification`.
- Expose `RenderJSON()` function
