### PR TITLE
chore: update title for connection spec

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,7 +132,7 @@ When you want to contribute with a new connector or operator, you need to create
       - The `release_stage` property refers to the release stage of the component (not to be mixed with the pre-release label of the version).
         Unimplemented stages (`RELEASE_STAGE_COMING_SOON` or `RELEASE_STAGE_OPEN_FOR_CONTRIBUTION`) will hide the component from the console (i.e. they can't be used in pipelines) but they will appear in the `ListComponentDefinitions` endpoint.
         This will showcase the upcoming component at [instill.tech](https://instill.tech).
-    - We define the `resource_configuration` in this file, which defines the connector resource setup.
+    - We define the `connection_configuration` in this file, which defines the connector connection setup.
 - `tasks.json`
     - You can refer to [OpenAI connector](../pkg/connector/openai/v0/config/tasks.json) as an example.
     - A component can have multiple tasks.

--- a/pkg/base/testdata/connectorDef.json
+++ b/pkg/base/testdata/connectorDef.json
@@ -25,7 +25,7 @@
       "required": [
         "api_key"
       ],
-      "title": "OpenAI Connector Resource",
+      "title": "OpenAI Connection",
       "type": "object"
     }
   },

--- a/pkg/base/testdata/wantConnectorDefinition.json
+++ b/pkg/base/testdata/wantConnectorDefinition.json
@@ -127,7 +127,7 @@
           "required": [
             "api_key"
           ],
-          "title": "OpenAI Connector Resource",
+          "title": "OpenAI Connection",
           "type": "object"
         }
       },

--- a/pkg/connector/archetypeai/v0/config/definition.json
+++ b/pkg/connector/archetypeai/v0/config/definition.json
@@ -32,7 +32,7 @@
       "required": [
         "api_key"
       ],
-      "title": "Archetype AI Connector Specification",
+      "title": "Archetype AI Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/bigquery/v0/config/definition.json
+++ b/pkg/connector/bigquery/v0/config/definition.json
@@ -70,7 +70,7 @@
         "dataset_id",
         "table_name"
       ],
-      "title": "BigQuery Connector Spec",
+      "title": "BigQuery Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/googlecloudstorage/v0/config/definition.json
+++ b/pkg/connector/googlecloudstorage/v0/config/definition.json
@@ -45,7 +45,7 @@
         "json_key",
         "bucket_name"
       ],
-      "title": "Google Cloud Storage Connector Spec",
+      "title": "Google Cloud Storage Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/googlesearch/v0/config/definition.json
+++ b/pkg/connector/googlesearch/v0/config/definition.json
@@ -38,7 +38,7 @@
         "api_key",
         "cse_id"
       ],
-      "title": "Google Search Connector Spec",
+      "title": "Google Search Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/huggingface/v0/config/definition.json
+++ b/pkg/connector/huggingface/v0/config/definition.json
@@ -76,7 +76,7 @@
         "base_url",
         "is_custom_endpoint"
       ],
-      "title": "Hugging Face Connector Spec",
+      "title": "Hugging Face Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/numbers/v0/config/definition.json
+++ b/pkg/connector/numbers/v0/config/definition.json
@@ -30,7 +30,7 @@
       "required": [
         "capture_token"
       ],
-      "title": "Numbers Protocol Blockchain Connector Spec",
+      "title": "Numbers Protocol Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/openai/v0/config/definition.json
+++ b/pkg/connector/openai/v0/config/definition.json
@@ -46,7 +46,7 @@
       "required": [
         "api_key"
       ],
-      "title": "OpenAI Connector Resource",
+      "title": "OpenAI Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/pinecone/v0/config/definition.json
+++ b/pkg/connector/pinecone/v0/config/definition.json
@@ -45,7 +45,7 @@
         "api_key",
         "url"
       ],
-      "title": "Pinecone Connector Spec",
+      "title": "Pinecone Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/redis/v0/config/definition.json
+++ b/pkg/connector/redis/v0/config/definition.json
@@ -193,7 +193,7 @@
         "host",
         "port"
       ],
-      "title": "Redis Connector Resource",
+      "title": "Redis Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/restapi/v0/config/definition.json
+++ b/pkg/connector/restapi/v0/config/definition.json
@@ -185,7 +185,7 @@
       "required": [
         "authentication"
       ],
-      "title": "REST API Connector Spec",
+      "title": "REST API Connection",
       "type": "object"
     }
   },

--- a/pkg/connector/stabilityai/v0/config/definition.json
+++ b/pkg/connector/stabilityai/v0/config/definition.json
@@ -31,7 +31,7 @@
       "required": [
         "api_key"
       ],
-      "title": "Stability AI Connector Resource",
+      "title": "Stability AI Connection",
       "type": "object"
     }
   },

--- a/tools/compogen/cmd/testdata/readme-connector.txt
+++ b/tools/compogen/cmd/testdata/readme-connector.txt
@@ -41,7 +41,7 @@ cmp pkg/dummy/README.mdx want-readme.mdx
       "required": [
         "api_key"
       ],
-      "title": "OpenAI Connector Resource",
+      "title": "OpenAI Connection",
       "type": "object"
     }
   },


### PR DESCRIPTION
Because

- We've retired the connector "resource" and made it a "connection" field in the component spec.

This commit

- Updates the title for the connection spec.