### PR TITLE
feat: allow global API key on OpenAI connector

### DIFF
--- a/pkg/base/execution.go
+++ b/pkg/base/execution.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/instill-ai/x/errmsg"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -137,4 +138,19 @@ func (e *ExecutionWrapper) Execute(inputs []*structpb.Struct) ([]*structpb.Struc
 	}
 
 	return outputs, err
+}
+
+// ConnectionGlobalSecret is a keyword to reference a global secret in a
+// connection configuration. When a connector detects this value in a
+// configuration parameter, it will used the pre-configured value, injected at
+// initialization.
+const ConnectionGlobalSecret = "__INSTILL_CONNECTION"
+
+// NewUnresolvedGlobalSecret returns an end-user error signaling that  the
+// connection configuration references a global secret that
+func NewUnresolvedGlobalSecret(key string) error {
+	return errmsg.AddMessage(
+		fmt.Errorf("unresolved global secret"),
+		fmt.Sprintf("The connection field %s can't reference a global secret.", key),
+	)
 }

--- a/pkg/base/execution.go
+++ b/pkg/base/execution.go
@@ -140,11 +140,11 @@ func (e *ExecutionWrapper) Execute(inputs []*structpb.Struct) ([]*structpb.Struc
 	return outputs, err
 }
 
-// ConnectionGlobalSecret is a keyword to reference a global secret in a
-// connection configuration. When a connector detects this value in a
+// CredentialGlobalSecret is a keyword to reference a global secret in a
+// component configuration. When a component detects this value in a
 // configuration parameter, it will used the pre-configured value, injected at
 // initialization.
-const ConnectionGlobalSecret = "__INSTILL_CONNECTION"
+const CredentialGlobalSecret = "__INSTILL_CREDENTIAL"
 
 // NewUnresolvedGlobalSecret returns an end-user error signaling that  the
 // connection configuration references a global secret that

--- a/pkg/connector/main.go
+++ b/pkg/connector/main.go
@@ -63,7 +63,7 @@ func Init(logger *zap.Logger, usageHandler base.UsageHandler, secrets Connection
 		{
 			// OpenAI
 			conn := openai.Init(logger, usageHandler)
-			conn = conn.WithGlobalConnection(secrets[conn.GetID()])
+			conn = conn.WithGlobalCredentials(secrets[conn.GetID()])
 			conStore.Import(conn)
 		}
 

--- a/pkg/connector/main.go
+++ b/pkg/connector/main.go
@@ -42,7 +42,13 @@ type connector struct {
 	con base.IConnector
 }
 
-func Init(logger *zap.Logger, usageHandler base.UsageHandler) *ConnectorStore {
+// ConnectionSecrets contains the global connection secrets of each
+// implemented connector (referenced by ID). Connectors may use these secrets
+// to skip the connector configuration step and have a ready-to-run
+// connection.
+type ConnectionSecrets map[string]map[string]any
+
+func Init(logger *zap.Logger, usageHandler base.UsageHandler, secrets ConnectionSecrets) *ConnectorStore {
 	once.Do(func() {
 
 		conStore = &ConnectorStore{
@@ -53,7 +59,14 @@ func Init(logger *zap.Logger, usageHandler base.UsageHandler) *ConnectorStore {
 		conStore.Import(stabilityai.Init(logger, usageHandler))
 		conStore.Import(instill.Init(logger, usageHandler))
 		conStore.Import(huggingface.Init(logger, usageHandler))
-		conStore.Import(openai.Init(logger, usageHandler))
+
+		{
+			// OpenAI
+			conn := openai.Init(logger, usageHandler)
+			conn = conn.WithGlobalConnection(secrets[conn.GetID()])
+			conStore.Import(conn)
+		}
+
 		conStore.Import(archetypeai.Init(logger, usageHandler))
 		conStore.Import(numbers.Init(logger, usageHandler))
 		conStore.Import(airbyte.Init(logger, usageHandler))

--- a/pkg/connector/openai/v0/main.go
+++ b/pkg/connector/openai/v0/main.go
@@ -85,9 +85,9 @@ func readFromSecrets(key string, s map[string]any) string {
 	return ""
 }
 
-// WithGlobalConnection reads the global connection configuration, which can
+// WithGlobalCredentials reads the global connection configuration, which can
 // be used to execute the connector with globally defined secrets.
-func (c *Connector) WithGlobalConnection(s map[string]any) *Connector {
+func (c *Connector) WithGlobalCredentials(s map[string]any) *Connector {
 	c.globalAPIKey = readFromSecrets(cfgAPIKey, s)
 
 	return c
@@ -115,7 +115,7 @@ func (c *Connector) CreateExecution(sysVars map[string]any, connection *structpb
 // and replaces them by the global secret injected during initialization.
 func (c *Connector) resolveSecrets(conn *structpb.Struct) (*structpb.Struct, error) {
 	apiKey := conn.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey == base.ConnectionGlobalSecret {
+	if apiKey == base.CredentialGlobalSecret {
 		if c.globalAPIKey == "" {
 			return nil, base.NewUnresolvedGlobalSecret(cfgAPIKey)
 		}


### PR DESCRIPTION
Because

- We need connectors like OpenAI to use globally configured secrets to run executions without credentials.

This commit

- Injects a global secret for the OpenAI API key on intialization.
- Transforms a keyword value in that configuration parameter into the secret.
