### PR TITLE
chore(instill): increase msg size for gRPC connection

### DIFF
--- a/pkg/connector/instill/v0/client.go
+++ b/pkg/connector/instill/v0/client.go
@@ -12,6 +12,8 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
+const MaxPayloadSize int = 1024 * 1024 * 32
+
 // initModelPublicServiceClient initialises a ModelPublicServiceClient instance
 func initModelPublicServiceClient(serverURL string) (modelPB.ModelPublicServiceClient, *grpc.ClientConn) {
 	var clientDialOpts grpc.DialOption
@@ -23,7 +25,7 @@ func initModelPublicServiceClient(serverURL string) (modelPB.ModelPublicServiceC
 	}
 
 	serverURL = stripProtocolFromURL(serverURL)
-	clientConn, err := grpc.Dial(serverURL, clientDialOpts)
+	clientConn, err := grpc.Dial(serverURL, clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxPayloadSize), grpc.MaxCallSendMsgSize(MaxPayloadSize)))
 	if err != nil {
 		return nil, nil
 	}


### PR DESCRIPTION
Because

- the gRPC connection message size limit is still using the default value.
 
This commit

- increases the message size for the gRPC connection.