### PR TITLE
chore: add context to UsageHandler methods

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -396,7 +396,7 @@ the `hello` component will only need to override the following methods:
   will return an object that implements the `Execute` method.
   - `ExecutionWrapper` will wrap the execution call with the input and output
     schema validation.
-- `Execute([]*structpb.Struct) ([]*structpb.Struct, error)` is the most
+- `Execute(context.Context []*structpb.Struct) ([]*structpb.Struct, error)` is the most
   important function in the component. All the data manipulation will take place
   here.
 
@@ -463,7 +463,7 @@ func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.E
 	return &base.ExecutionWrapper{Execution: e}, nil
 }
 
-func (e *execution) Execute(_ []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(context.Context, []*structpb.Struct) ([]*structpb.Struct, error) {
 	return nil, nil
 }
 ```
@@ -498,7 +498,7 @@ func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.E
 	return &base.ExecutionWrapper{Execution: e}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := make([]*structpb.Struct, len(inputs))
 
 	// An execution  might take several inputs. One result will be returned for
@@ -549,6 +549,7 @@ import (
 
 func TestOperator_Execute(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
 	bo := base.BaseOperator{Logger: zap.NewNop()}
 	operator := Init(bo)
@@ -560,7 +561,7 @@ func TestOperator_Execute(t *testing.T) {
 		pbIn, err := structpb.NewStruct(map[string]any{"target": "bolero-wombat"})
 		c.Assert(err, qt.IsNil)
 
-		got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+		got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNil)
 		c.Assert(got, qt.HasLen, 1)
 

--- a/pkg/base/execution.go
+++ b/pkg/base/execution.go
@@ -26,6 +26,7 @@ type IExecution interface {
 	GetLogger() *zap.Logger
 	GetTaskInputSchema() string
 	GetTaskOutputSchema() string
+	GetSystemVariables() map[string]any
 
 	UsesSecret() bool
 	UsageHandlerCreator() UsageHandlerCreator

--- a/pkg/base/usage.go
+++ b/pkg/base/usage.go
@@ -1,12 +1,16 @@
 package base
 
-import "google.golang.org/protobuf/types/known/structpb"
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
 
 // UsageHandler allows the component execution wrapper to add checks and
 // collect usage metrics around a component execution.
 type UsageHandler interface {
-	Check(inputs []*structpb.Struct) error
-	Collect(inputs, outputs []*structpb.Struct) error
+	Check(ctx context.Context, inputs []*structpb.Struct) error
+	Collect(ctx context.Context, inputs, outputs []*structpb.Struct) error
 }
 
 // UsageHandlerCreator returns a function to initialize a UsageHandler.
@@ -14,8 +18,8 @@ type UsageHandlerCreator func(IExecution) UsageHandler
 
 type noopUsageHandler struct{}
 
-func (h *noopUsageHandler) Check([]*structpb.Struct) error { return nil }
-func (h *noopUsageHandler) Collect(_, _ []*structpb.Struct) error {
+func (h *noopUsageHandler) Check(context.Context, []*structpb.Struct) error { return nil }
+func (h *noopUsageHandler) Collect(_ context.Context, _, _ []*structpb.Struct) error {
 	return nil
 }
 

--- a/pkg/connector/airbyte/v0/main.go
+++ b/pkg/connector/airbyte/v0/main.go
@@ -1,6 +1,7 @@
 package airbyte
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"sync"
@@ -44,10 +45,10 @@ func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb
 	}}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(context.Context, []*structpb.Struct) ([]*structpb.Struct, error) {
 	return nil, fmt.Errorf("the Airbyte connector has been removed")
 }
 
-func (c *connector) Test(sysVars map[string]any, connection *structpb.Struct) error {
+func (c *connector) Test(map[string]any, *structpb.Struct) error {
 	return fmt.Errorf("the Airbyte connector has been removed")
 }

--- a/pkg/connector/archetypeai/v0/connector_test.go
+++ b/pkg/connector/archetypeai/v0/connector_test.go
@@ -1,6 +1,7 @@
 package archetypeai
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -100,6 +101,7 @@ var (
 
 func TestConnector_Execute(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
 	testcases := []struct {
 		name string
@@ -265,7 +267,7 @@ func TestConnector_Execute(t *testing.T) {
 			pbIn, err := base.ConvertToStructpb(tc.in)
 			c.Assert(err, qt.IsNil)
 
-			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 			if tc.wantErr != "" {
 				c.Check(errmsg.Message(err), qt.Matches, tc.wantErr)
 				return

--- a/pkg/connector/archetypeai/v0/main.go
+++ b/pkg/connector/archetypeai/v0/main.go
@@ -3,6 +3,7 @@ package archetypeai
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"fmt"
 	"strings"
@@ -81,7 +82,7 @@ func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb
 }
 
 // Execute performs calls the Archetype AI API to execute a task.
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := make([]*structpb.Struct, len(inputs))
 
 	for i, input := range inputs {

--- a/pkg/connector/bigquery/v0/main.go
+++ b/pkg/connector/bigquery/v0/main.go
@@ -70,7 +70,7 @@ func getTableName(config *structpb.Struct) string {
 	return config.GetFields()["table_name"].GetStringValue()
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
 	client, err := NewClient(getJSONKey(e.Connection), getProjectID(e.Connection))

--- a/pkg/connector/googlecloudstorage/v0/main.go
+++ b/pkg/connector/googlecloudstorage/v0/main.go
@@ -63,7 +63,7 @@ func getJSONKey(config *structpb.Struct) string {
 	return config.GetFields()["json_key"].GetStringValue()
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
 	client, err := NewClient(getJSONKey(e.Connection))

--- a/pkg/connector/googlesearch/v0/main.go
+++ b/pkg/connector/googlesearch/v0/main.go
@@ -66,7 +66,7 @@ func getSearchEngineID(config *structpb.Struct) string {
 	return config.GetFields()["cse_id"].GetStringValue()
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 
 	service, err := NewService(getAPIKey(e.Connection))
 	if err != nil || service == nil {

--- a/pkg/connector/huggingface/v0/connector_test.go
+++ b/pkg/connector/huggingface/v0/connector_test.go
@@ -1,6 +1,7 @@
 package huggingface
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -222,6 +223,7 @@ func TestConnector_ExecuteSpeechRecognition(t *testing.T) {
 func testTask(c *qt.C, p taskParams) {
 	bc := base.Connector{Logger: zap.NewNop()}
 	connector := Init(bc)
+	ctx := context.Background()
 
 	c.Run("nok - HTTP client error - "+p.task, func(c *qt.C) {
 		c.Parallel()
@@ -238,7 +240,7 @@ func testTask(c *qt.C, p taskParams) {
 		c.Assert(err, qt.IsNil)
 		pbIn.Fields["model"] = structpb.NewStringValue(model)
 
-		_, err = exec.Execution.Execute([]*structpb.Struct{pbIn})
+		_, err = exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNotNil)
 		c.Check(err, qt.ErrorMatches, ".*no such host")
 		c.Check(errmsg.Message(err), qt.Matches, "Failed to call .*check that the connector configuration is correct.")
@@ -326,7 +328,7 @@ func testTask(c *qt.C, p taskParams) {
 			c.Assert(err, qt.IsNil)
 			pbIn.Fields["model"] = structpb.NewStringValue(model)
 
-			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 			if tc.wantErr != "" {
 				c.Check(err, qt.IsNotNil)
 				c.Check(errmsg.Message(err), qt.Equals, tc.wantErr)

--- a/pkg/connector/huggingface/v0/main.go
+++ b/pkg/connector/huggingface/v0/main.go
@@ -2,6 +2,7 @@
 package huggingface
 
 import (
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
@@ -101,7 +102,7 @@ func wrapSliceInStruct(data []byte, key string) (*structpb.Struct, error) {
 	}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	client := newClient(e.Connection, e.GetLogger())
 	outputs := []*structpb.Struct{}
 

--- a/pkg/connector/instill/v0/main.go
+++ b/pkg/connector/instill/v0/main.go
@@ -98,7 +98,7 @@ func getRequestMetadata(vars map[string]any) metadata.MD {
 	)
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	var err error
 
 	if len(inputs) <= 0 || inputs[0] == nil {
@@ -116,7 +116,7 @@ func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	}
 
 	modelNameSplits := strings.Split(inputs[0].GetFields()["model_name"].GetStringValue(), "/")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
 	ctx = metadata.NewOutgoingContext(ctx, getRequestMetadata(e.SystemVariables))

--- a/pkg/connector/numbers/v0/main.go
+++ b/pkg/connector/numbers/v0/main.go
@@ -3,6 +3,7 @@ package numbers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -191,7 +192,7 @@ func (e *execution) registerAsset(data []byte, reg Register) (string, error) {
 	}
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 
 	var outputs []*structpb.Struct
 

--- a/pkg/connector/openai/v0/main.go
+++ b/pkg/connector/openai/v0/main.go
@@ -2,6 +2,7 @@
 package openai
 
 import (
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
@@ -140,7 +141,7 @@ func (e *execution) UsesSecret() bool {
 	return e.usesSecret
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	client := newClient(e.Connection, e.GetLogger())
 	outputs := []*structpb.Struct{}
 

--- a/pkg/connector/pinecone/v0/connector_test.go
+++ b/pkg/connector/pinecone/v0/connector_test.go
@@ -1,6 +1,7 @@
 package pinecone
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -90,6 +91,7 @@ var (
 
 func TestConnector_Execute(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
 	testcases := []struct {
 		name string
@@ -230,7 +232,7 @@ func TestConnector_Execute(t *testing.T) {
 			pbIn, err := base.ConvertToStructpb(tc.execIn)
 			c.Assert(err, qt.IsNil)
 
-			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 			c.Check(err, qt.IsNil)
 
 			c.Assert(got, qt.HasLen, 1)
@@ -258,7 +260,7 @@ func TestConnector_Execute(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn := new(structpb.Struct)
-		_, err = exec.Execution.Execute([]*structpb.Struct{pbIn})
+		_, err = exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNotNil)
 
 		want := "Pinecone responded with a 400 status code. Cannot provide both ID and vector at the same time."
@@ -274,7 +276,7 @@ func TestConnector_Execute(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn := new(structpb.Struct)
-		_, err = exec.Execution.Execute([]*structpb.Struct{pbIn})
+		_, err = exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNotNil)
 
 		want := "Failed to call http://no-such.host/.*. Please check that the connector configuration is correct."

--- a/pkg/connector/pinecone/v0/main.go
+++ b/pkg/connector/pinecone/v0/main.go
@@ -2,6 +2,7 @@
 package pinecone
 
 import (
+	"context"
 	_ "embed"
 	"sync"
 
@@ -73,7 +74,7 @@ func getURL(config *structpb.Struct) string {
 	return config.GetFields()["url"].GetStringValue()
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	req := newClient(e.Connection, e.GetLogger()).R()
 	outputs := []*structpb.Struct{}
 

--- a/pkg/connector/redis/v0/main.go
+++ b/pkg/connector/redis/v0/main.go
@@ -53,7 +53,7 @@ func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb
 	}}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
 	client, err := NewClient(e.Connection)

--- a/pkg/connector/restapi/v0/connector_test.go
+++ b/pkg/connector/restapi/v0/connector_test.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -28,6 +29,7 @@ var (
 
 func TestConnector_Execute(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
 	bc := base.Connector{Logger: zap.NewNop()}
 	connector := Init(bc)
@@ -42,7 +44,7 @@ func TestConnector_Execute(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn := new(structpb.Struct)
-		_, err = exec.Execution.Execute([]*structpb.Struct{pbIn})
+		_, err = exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNotNil)
 
 		want := "FOOBAR task is not supported."
@@ -81,7 +83,7 @@ func TestConnector_Execute(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+		got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNil)
 
 		resp := got[0].AsMap()
@@ -112,7 +114,7 @@ func TestConnector_Execute(t *testing.T) {
 
 		c.Assert(err, qt.IsNil)
 
-		got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+		got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNil)
 
 		resp := got[0].AsMap()
@@ -143,7 +145,7 @@ func TestConnector_Execute(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+		got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNil)
 
 		resp := got[0].AsMap()

--- a/pkg/connector/restapi/v0/main.go
+++ b/pkg/connector/restapi/v0/main.go
@@ -2,6 +2,7 @@
 package restapi
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -111,7 +112,7 @@ func getAuthentication(config *structpb.Struct) (authentication, error) {
 	}
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 
 	method, ok := taskMethod[e.Task]
 	if !ok {

--- a/pkg/connector/stabilityai/v0/connector_test.go
+++ b/pkg/connector/stabilityai/v0/connector_test.go
@@ -1,6 +1,7 @@
 package stabilityai
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -40,6 +41,7 @@ const (
 
 func TestConnector_ExecuteImageFromText(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
 	weight := 0.5
 	text := "a cat and a dog"
@@ -106,7 +108,7 @@ func TestConnector_ExecuteImageFromText(t *testing.T) {
 			})
 			c.Assert(err, qt.IsNil)
 
-			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 			if tc.wantErr != "" {
 				c.Check(errmsg.Message(err), qt.Equals, tc.wantErr)
 				return
@@ -124,7 +126,7 @@ func TestConnector_ExecuteImageFromText(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn := new(structpb.Struct)
-		_, err = exec.Execution.Execute([]*structpb.Struct{pbIn})
+		_, err = exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNotNil)
 
 		want := "FOOBAR task is not supported."
@@ -134,6 +136,7 @@ func TestConnector_ExecuteImageFromText(t *testing.T) {
 
 func TestConnector_ExecuteImageFromImage(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
 	weight := 0.5
 	text := "a cat and a dog"
@@ -200,7 +203,7 @@ func TestConnector_ExecuteImageFromImage(t *testing.T) {
 			})
 			c.Assert(err, qt.IsNil)
 
-			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 			if tc.wantErr != "" {
 				c.Check(errmsg.Message(err), qt.Equals, tc.wantErr)
 				return
@@ -218,7 +221,7 @@ func TestConnector_ExecuteImageFromImage(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn := new(structpb.Struct)
-		_, err = exec.Execution.Execute([]*structpb.Struct{pbIn})
+		_, err = exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 		c.Check(err, qt.IsNotNil)
 
 		want := "FOOBAR task is not supported."

--- a/pkg/connector/stabilityai/v0/main.go
+++ b/pkg/connector/stabilityai/v0/main.go
@@ -2,6 +2,7 @@
 package stabilityai
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"sync"
@@ -73,7 +74,7 @@ func getBasePath(config *structpb.Struct) string {
 	return v.GetStringValue()
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	client := newClient(e.Connection, e.GetLogger())
 	outputs := []*structpb.Struct{}
 

--- a/pkg/connector/website/v0/main.go
+++ b/pkg/connector/website/v0/main.go
@@ -2,6 +2,7 @@
 package website
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"sync"
@@ -50,7 +51,7 @@ func (c *connector) CreateExecution(sysVars map[string]any, connection *structpb
 	}}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
 	for _, input := range inputs {

--- a/pkg/operator/base64/v0/main.go
+++ b/pkg/operator/base64/v0/main.go
@@ -2,6 +2,7 @@
 package base64
 
 import (
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
@@ -57,7 +58,7 @@ func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.E
 	}}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
 	for _, input := range inputs {

--- a/pkg/operator/end/v0/main.go
+++ b/pkg/operator/end/v0/main.go
@@ -1,6 +1,7 @@
 package end
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"sync"
@@ -44,7 +45,7 @@ func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.E
 	}}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	return nil, fmt.Errorf("the Airbyte operator has been removed")
 }
 

--- a/pkg/operator/image/v0/draw_test.go
+++ b/pkg/operator/image/v0/draw_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestDrawClassification(t *testing.T) {
 	e := &execution{}
 	e.Task = "TASK_DRAW_CLASSIFICATION"
 
-	if _, err := e.Execute(inputs); err != nil {
+	if _, err := e.Execute(context.Background(), inputs); err != nil {
 		t.Fatalf("drawClassification returned an error: %v", err)
 	}
 }
@@ -79,7 +80,7 @@ func TestDrawDetection(t *testing.T) {
 	e := &execution{}
 	e.Task = "TASK_DRAW_DETECTION"
 
-	if _, err := e.Execute(inputs); err != nil {
+	if _, err := e.Execute(context.Background(), inputs); err != nil {
 		t.Fatalf("drawDetection returned an error: %v", err)
 	}
 }
@@ -109,7 +110,7 @@ func TestDrawKeypoint(t *testing.T) {
 	e := &execution{}
 	e.Task = "TASK_DRAW_KEYPOINT"
 
-	if _, err := e.Execute(inputs); err != nil {
+	if _, err := e.Execute(context.Background(), inputs); err != nil {
 		t.Fatalf("drawKeypoint returned an error: %v", err)
 	}
 }
@@ -138,7 +139,7 @@ func TestDrawOCR(t *testing.T) {
 	e := &execution{}
 	e.Task = "TASK_DRAW_OCR"
 
-	if _, err := e.Execute(inputs); err != nil {
+	if _, err := e.Execute(context.Background(), inputs); err != nil {
 		t.Fatalf("drawKeypoint returned an error: %v", err)
 	}
 }
@@ -176,7 +177,7 @@ func TestDrawInstanceSegmentation(t *testing.T) {
 	e := &execution{}
 	e.Task = "TASK_DRAW_INSTANCE_SEGMENTATION"
 
-	if _, err := e.Execute(inputs); err != nil {
+	if _, err := e.Execute(context.Background(), inputs); err != nil {
 		t.Fatalf("drawInstanceSegmentation returned an error: %v", err)
 	}
 }
@@ -198,7 +199,7 @@ func TestDrawSemanticSegmentation(t *testing.T) {
 	e := &execution{}
 	e.Task = "TASK_DRAW_SEMANTIC_SEGMENTATION"
 
-	if _, err := e.Execute(inputs); err != nil {
+	if _, err := e.Execute(context.Background(), inputs); err != nil {
 		t.Fatalf("drawSemanticSegmentation returned an error: %v", err)
 	}
 }

--- a/pkg/operator/image/v0/main.go
+++ b/pkg/operator/image/v0/main.go
@@ -3,6 +3,7 @@ package image
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"image"
@@ -56,7 +57,7 @@ func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.E
 }
 
 // Execute executes the derived execution
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 	var base64ByteImg []byte
 	for _, input := range inputs {

--- a/pkg/operator/json/v0/main.go
+++ b/pkg/operator/json/v0/main.go
@@ -2,6 +2,7 @@
 package json
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -150,7 +151,7 @@ func (e *execution) jq(in *structpb.Struct) (*structpb.Struct, error) {
 	return out, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := make([]*structpb.Struct, len(inputs))
 
 	for i, input := range inputs {

--- a/pkg/operator/json/v0/operator_test.go
+++ b/pkg/operator/json/v0/operator_test.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -23,6 +24,7 @@ var asMap = map[string]any{"a": "27", "b": 27}
 
 func TestOperator_Execute(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
 	testcases := []struct {
 		name string
@@ -125,7 +127,7 @@ func TestOperator_Execute(t *testing.T) {
 			pbIn, err := structpb.NewStruct(tc.in)
 			c.Assert(err, qt.IsNil)
 
-			got, err := exec.Execution.Execute([]*structpb.Struct{pbIn})
+			got, err := exec.Execution.Execute(ctx, []*structpb.Struct{pbIn})
 			if tc.wantErr != "" {
 				c.Check(errmsg.Message(err), qt.Matches, tc.wantErr)
 				return

--- a/pkg/operator/start/v0/main.go
+++ b/pkg/operator/start/v0/main.go
@@ -1,6 +1,7 @@
 package start
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"sync"
@@ -44,7 +45,7 @@ func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.E
 	}}, nil
 }
 
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	return nil, fmt.Errorf("the Airbyte operator has been removed")
 }
 

--- a/pkg/operator/text/v0/convert_test.go
+++ b/pkg/operator/text/v0/convert_test.go
@@ -1,6 +1,7 @@
 package text
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -79,7 +80,7 @@ func TestConvertToText(t *testing.T) {
 			e := &execution{}
 			e.Task = "TASK_CONVERT_TO_TEXT"
 
-			if outputs, err := e.Execute(inputs); err != nil {
+			if outputs, err := e.Execute(context.Background(), inputs); err != nil {
 				t.Fatalf("convertToText returned an error: %v", err)
 			} else if outputs[0].Fields["body"].GetStringValue() == "" {
 				t.Fatal("convertToText returned an empty body")

--- a/pkg/operator/text/v0/main.go
+++ b/pkg/operator/text/v0/main.go
@@ -2,6 +2,7 @@
 package text
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -55,7 +56,7 @@ func (o *operator) CreateExecution(sysVars map[string]any, task string) (*base.E
 }
 
 // Execute executes the derived execution
-func (e *execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	outputs := []*structpb.Struct{}
 
 	for _, input := range inputs {

--- a/pkg/operator/text/v0/split_test.go
+++ b/pkg/operator/text/v0/split_test.go
@@ -1,6 +1,7 @@
 package text
 
 import (
+	"context"
 	"testing"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -21,7 +22,7 @@ func TestSplitByToken(t *testing.T) {
 	e := &execution{}
 	e.Task = "TASK_SPLIT_BY_TOKEN"
 
-	if _, err := e.Execute(inputs); err != nil {
+	if _, err := e.Execute(context.Background(), inputs); err != nil {
 		t.Fatalf("splitByToken returned an error: %v", err)
 	}
 }


### PR DESCRIPTION
Because

- We want the pipeline trigger context to be propagated to the component execution and usage handler.

This commit

- Adds a context param to `Execute`, `Check` and `Collect`.
