### PR TITLE
feat: add sourceTag for pinecone

### DIFF
--- a/pkg/connector/pinecone/v0/main.go
+++ b/pkg/connector/pinecone/v0/main.go
@@ -62,6 +62,7 @@ func newClient(config *structpb.Struct, logger *zap.Logger) *httpclient.Client {
 	)
 
 	c.SetHeader("Api-Key", getAPIKey(config))
+	c.SetHeader("User-Agent", "source_tag=instillai")
 
 	return c
 }


### PR DESCRIPTION
Because

- pinecone needs to track the activities

This commit

- add instillai to SourceTag
