### PR TITLE
feat: add additional attribute in JSON schema for Instill Credit

### DIFF
--- a/pkg/base/testdata/connectorDef.json
+++ b/pkg/base/testdata/connectorDef.json
@@ -16,7 +16,7 @@
       "properties": {
         "api_key": {
           "description": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"

--- a/pkg/base/testdata/wantConnectorDefinition.json
+++ b/pkg/base/testdata/wantConnectorDefinition.json
@@ -117,7 +117,7 @@
           "properties": {
             "api_key": {
               "description": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
-              "instillCredentialField": true,
+              "instillSecret": true,
               "instillShortDescription": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
               "instillUIOrder": 0,
               "title": "API Key",

--- a/pkg/connector/archetypeai/v0/config/definition.json
+++ b/pkg/connector/archetypeai/v0/config/definition.json
@@ -23,7 +23,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"

--- a/pkg/connector/archetypeai/v0/config/definition.json
+++ b/pkg/connector/archetypeai/v0/config/definition.json
@@ -32,6 +32,9 @@
       "required": [
         "api_key"
       ],
+      "instillEditOnNodeFields": [
+        "api_key"
+      ],
       "title": "Archetype AI Connection",
       "type": "object"
     }

--- a/pkg/connector/bigquery/v0/config/definition.json
+++ b/pkg/connector/bigquery/v0/config/definition.json
@@ -70,6 +70,12 @@
         "dataset_id",
         "table_name"
       ],
+      "instillEditOnNodeFields": [
+        "json_key",
+        "project_id",
+        "dataset_id",
+        "table_name"
+      ],
       "title": "BigQuery Connection",
       "type": "object"
     }

--- a/pkg/connector/bigquery/v0/config/definition.json
+++ b/pkg/connector/bigquery/v0/config/definition.json
@@ -33,7 +33,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "instillUIMultiline": true,
           "title": "JSON Key File contents",

--- a/pkg/connector/googlecloudstorage/v0/config/definition.json
+++ b/pkg/connector/googlecloudstorage/v0/config/definition.json
@@ -21,7 +21,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": false,
+          "instillSecret": false,
           "instillUIOrder": 0,
           "title": "Bucket Name",
           "type": "string"
@@ -34,7 +34,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 1,
           "instillUIMultiline": true,
           "title": "JSON Key File contents",

--- a/pkg/connector/googlecloudstorage/v0/config/definition.json
+++ b/pkg/connector/googlecloudstorage/v0/config/definition.json
@@ -45,6 +45,10 @@
         "json_key",
         "bucket_name"
       ],
+      "instillEditOnNodeFields": [
+        "json_key",
+        "bucket_name"
+      ],
       "title": "Google Cloud Storage Connection",
       "type": "object"
     }

--- a/pkg/connector/googlesearch/v0/config/definition.json
+++ b/pkg/connector/googlesearch/v0/config/definition.json
@@ -18,7 +18,7 @@
           "instillUpstreamTypes": [
             "reference"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"
@@ -28,7 +28,7 @@
           "instillUpstreamTypes": [
             "value"
           ],
-          "instillCredentialField": false,
+          "instillSecret": false,
           "instillUIOrder": 1,
           "title": "Search Engine ID",
           "type": "string"

--- a/pkg/connector/googlesearch/v0/config/definition.json
+++ b/pkg/connector/googlesearch/v0/config/definition.json
@@ -38,6 +38,10 @@
         "api_key",
         "cse_id"
       ],
+      "instillEditOnNodeFields": [
+        "api_key",
+        "cse_id"
+      ],
       "title": "Google Search Connection",
       "type": "object"
     }

--- a/pkg/connector/huggingface/v0/config/definition.json
+++ b/pkg/connector/huggingface/v0/config/definition.json
@@ -76,6 +76,11 @@
         "base_url",
         "is_custom_endpoint"
       ],
+      "instillEditOnNodeFields": [
+        "api_key",
+        "base_url",
+        "is_custom_endpoint"
+      ],
       "title": "Hugging Face Connection",
       "type": "object"
     }

--- a/pkg/connector/huggingface/v0/config/definition.json
+++ b/pkg/connector/huggingface/v0/config/definition.json
@@ -37,7 +37,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"
@@ -51,7 +51,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": false,
+          "instillSecret": false,
           "instillUIOrder": 1,
           "title": "Base URL",
           "type": "string"
@@ -65,7 +65,7 @@
           "instillAcceptFormats": [
             "boolean"
           ],
-          "instillCredentialField": false,
+          "instillSecret": false,
           "instillUIOrder": 2,
           "title": "Is Custom Endpoint",
           "type": "boolean"

--- a/pkg/connector/main.go
+++ b/pkg/connector/main.go
@@ -140,11 +140,9 @@ func (cs *Store) ListConnectorDefinitions(sysVars map[string]any, returnTombston
 	return defs
 }
 
-// IsCredentialField returns whether a given field in a connector contains
-// credentials.
-func (cs *Store) IsCredentialField(defUID uuid.UUID, target string) (bool, error) {
+func (cs *Store) IsSecretField(defUID uuid.UUID, target string) (bool, error) {
 	if con, ok := cs.connectorUIDMap[defUID]; ok {
-		return con.con.IsCredentialField(target), nil
+		return con.con.IsSecretField(target), nil
 	}
 	return false, fmt.Errorf("connector definition not found")
 }

--- a/pkg/connector/numbers/v0/config/definition.json
+++ b/pkg/connector/numbers/v0/config/definition.json
@@ -30,6 +30,9 @@
       "required": [
         "capture_token"
       ],
+      "instillEditOnNodeFields": [
+        "capture_token"
+      ],
       "title": "Numbers Protocol Connection",
       "type": "object"
     }

--- a/pkg/connector/numbers/v0/config/definition.json
+++ b/pkg/connector/numbers/v0/config/definition.json
@@ -21,7 +21,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "Capture token",
           "type": "string"

--- a/pkg/connector/openai/v0/config/definition.json
+++ b/pkg/connector/openai/v0/config/definition.json
@@ -47,6 +47,9 @@
       "required": [
         "api_key"
       ],
+      "instillEditOnNodeFields": [
+        "api_key"
+      ],
       "title": "OpenAI Connection",
       "type": "object"
     }

--- a/pkg/connector/openai/v0/config/definition.json
+++ b/pkg/connector/openai/v0/config/definition.json
@@ -25,7 +25,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"

--- a/pkg/connector/openai/v0/config/definition.json
+++ b/pkg/connector/openai/v0/config/definition.json
@@ -26,6 +26,7 @@
             "string"
           ],
           "instillSecret": true,
+          "instillCredential": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"

--- a/pkg/connector/openai/v0/config/tasks.json
+++ b/pkg/connector/openai/v0/config/tasks.json
@@ -260,6 +260,24 @@
             "reference",
             "template"
           ],
+          "instillCredentialMap": {
+            "values": [
+              "gpt-4-0125-preview",
+              "gpt-4-turbo-preview",
+              "gpt-4-1106-preview",
+              "gpt-4-vision-preview",
+              "gpt-4",
+              "gpt-4-0314",
+              "gpt-4-0613",
+              "gpt-4-32k",
+              "gpt-4-32k-0314",
+              "gpt-4-32k-0613",
+              "gpt-3.5-turbo"
+            ],
+            "targets": [
+              "connection.api_key"
+            ]
+          },
           "title": "Model"
         },
         "n": {

--- a/pkg/connector/pinecone/v0/config/definition.json
+++ b/pkg/connector/pinecone/v0/config/definition.json
@@ -22,7 +22,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"
@@ -35,7 +35,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": false,
+          "instillSecret": false,
           "instillUIOrder": 1,
           "title": "Pinecone Base URL",
           "type": "string"

--- a/pkg/connector/pinecone/v0/config/definition.json
+++ b/pkg/connector/pinecone/v0/config/definition.json
@@ -45,6 +45,10 @@
         "api_key",
         "url"
       ],
+      "instillEditOnNodeFields": [
+        "api_key",
+        "url"
+      ],
       "title": "Pinecone Connection",
       "type": "object"
     }

--- a/pkg/connector/redis/v0/config/definition.json
+++ b/pkg/connector/redis/v0/config/definition.json
@@ -193,6 +193,10 @@
         "host",
         "port"
       ],
+      "instillEditOnNodeFields": [
+        "host",
+        "port"
+      ],
       "title": "Redis Connection",
       "type": "object"
     }

--- a/pkg/connector/redis/v0/config/definition.json
+++ b/pkg/connector/redis/v0/config/definition.json
@@ -27,7 +27,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": false,
+          "instillSecret": false,
           "instillUIOrder": 0,
           "title": "Host",
           "type": "string"
@@ -40,7 +40,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 3,
           "title": "Password",
           "type": "string"
@@ -111,7 +111,7 @@
                   "instillAcceptFormats": [
                     "string"
                   ],
-                  "instillCredentialField": true,
+                  "instillSecret": true,
                   "instillUIOrder": 1,
                   "multiline": true,
                   "order": 1,
@@ -126,7 +126,7 @@
                   "instillAcceptFormats": [
                     "string"
                   ],
-                  "instillCredentialField": true,
+                  "instillSecret": true,
                   "instillUIOrder": 2,
                   "multiline": true,
                   "order": 2,
@@ -141,7 +141,7 @@
                   "instillAcceptFormats": [
                     "string"
                   ],
-                  "instillCredentialField": true,
+                  "instillSecret": true,
                   "instillUIOrder": 3,
                   "multiline": true,
                   "order": 3,

--- a/pkg/connector/restapi/v0/config/definition.json
+++ b/pkg/connector/restapi/v0/config/definition.json
@@ -55,7 +55,7 @@
                   "instillAcceptFormats": [
                     "string"
                   ],
-                  "instillCredentialField": true,
+                  "instillSecret": true,
                   "instillUIOrder": 2,
                   "order": 2,
                   "title": "Password",
@@ -131,7 +131,7 @@
                   "instillAcceptFormats": [
                     "string"
                   ],
-                  "instillCredentialField": true,
+                  "instillSecret": true,
                   "instillUIOrder": 2,
                   "order": 2,
                   "title": "Key Value",
@@ -163,7 +163,7 @@
                   "instillAcceptFormats": [
                     "string"
                   ],
-                  "instillCredentialField": true,
+                  "instillSecret": true,
                   "instillUIOrder": 1,
                   "order": 1,
                   "title": "Token",

--- a/pkg/connector/stabilityai/v0/config/definition.json
+++ b/pkg/connector/stabilityai/v0/config/definition.json
@@ -31,6 +31,9 @@
       "required": [
         "api_key"
       ],
+      "instillEditOnNodeFields": [
+        "api_key"
+      ],
       "title": "Stability AI Connection",
       "type": "object"
     }

--- a/pkg/connector/stabilityai/v0/config/definition.json
+++ b/pkg/connector/stabilityai/v0/config/definition.json
@@ -22,7 +22,7 @@
           "instillAcceptFormats": [
             "string"
           ],
-          "instillCredentialField": true,
+          "instillSecret": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"


### PR DESCRIPTION
Because

- We need to introduce new attributes in the JSON schema to help Console generate the corresponding Instill-Credit-supported models list.

This commit

- refactor: rename `instillCredentialField` to `instillSecret`
- feat(openai): add additional attribute in JSON schema to indicate which models support `instillSecret`
- feat: update `instillEditOnNodeFields` for all connectors
