### PR TITLE
chore: make input / output OpenAI fields public

### DIFF
--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -259,7 +259,7 @@ func (c *Connector) traverseSecretField(input *structpb.Value, prefix string, se
 
 // UsageHandlerCreator returns a function to initialize a UsageHandler.
 func (c *Connector) UsageHandlerCreator() UsageHandlerCreator {
-	return newNoopUsageHandler
+	return NewNoopUsageHandler
 }
 
 // ConnectorExecution implements the common methods for connector

--- a/pkg/base/operator.go
+++ b/pkg/base/operator.go
@@ -118,7 +118,7 @@ func (o *Operator) LoadOperatorDefinition(definitionJSONBytes []byte, tasksJSONB
 // UsageHandlerCreator returns a no-op usage handler initializer. For the
 // moment there are no use cases for usage collection in operators.
 func (o *Operator) UsageHandlerCreator() UsageHandlerCreator {
-	return newNoopUsageHandler
+	return NewNoopUsageHandler
 }
 
 // OperatorExecution implements the common methods for operator execution.

--- a/pkg/base/usage.go
+++ b/pkg/base/usage.go
@@ -23,6 +23,7 @@ func (h *noopUsageHandler) Collect(_ context.Context, _, _ []*structpb.Struct) e
 	return nil
 }
 
-func newNoopUsageHandler(IExecution) UsageHandler {
+// NewNoopUsageHandler is a no-op usage handler initializer.
+func NewNoopUsageHandler(IExecution) UsageHandler {
 	return new(noopUsageHandler)
 }

--- a/pkg/connector/openai/v0/connector_test.go
+++ b/pkg/connector/openai/v0/connector_test.go
@@ -45,31 +45,31 @@ func TestConnector_Execute(t *testing.T) {
 	}{
 		{
 			name:        "text generation",
-			task:        textGenerationTask,
+			task:        TextGenerationTask,
 			path:        completionsPath,
 			contentType: httpclient.MIMETypeJSON,
 		},
 		{
 			name:        "text embeddings",
-			task:        textEmbeddingsTask,
+			task:        TextEmbeddingsTask,
 			path:        embeddingsPath,
 			contentType: httpclient.MIMETypeJSON,
 		},
 		{
 			name:        "speech recognition",
-			task:        speechRecognitionTask,
+			task:        SpeechRecognitionTask,
 			path:        transcriptionsPath,
 			contentType: "multipart/form-data; boundary=.*",
 		},
 		{
 			name:        "text to speech",
-			task:        textToSpeechTask,
+			task:        TextToSpeechTask,
 			path:        createSpeechPath,
 			contentType: httpclient.MIMETypeJSON,
 		},
 		{
 			name:        "text to image",
-			task:        textToImageTask,
+			task:        TextToImageTask,
 			path:        imgGenerationPath,
 			contentType: httpclient.MIMETypeJSON,
 		},
@@ -209,13 +209,13 @@ func TestConnector_WithConfig(t *testing.T) {
 	cleanupConn := func() { once = sync.Once{} }
 	ctx := context.Background()
 
-	want := textCompletionOutput{
+	want := TextCompletionOutput{
 		Texts: []string{"hello!"},
 		Usage: usage{TotalTokens: 25},
 	}
 	resp := `{"usage": {"total_tokens": 25}, "choices": [{"message": {"content": "hello!"}}]}`
 
-	pbIn, err := base.ConvertToStructpb(textCompletionInput{
+	pbIn, err := base.ConvertToStructpb(TextCompletionInput{
 		Model:  "gpt-3.5-turbo",
 		Prompt: "what instrument did Yusef Lateef play?",
 		Images: []string{},
@@ -236,7 +236,7 @@ func TestConnector_WithConfig(t *testing.T) {
 	openAIServer := httptest.NewServer(h)
 	c.Cleanup(openAIServer.Close)
 
-	task := textGenerationTask
+	task := TextGenerationTask
 	bc := base.Connector{Logger: zap.NewNop()}
 
 	c.Run("nok - usage handler check error", func(c *qt.C) {

--- a/pkg/connector/openai/v0/main.go
+++ b/pkg/connector/openai/v0/main.go
@@ -19,12 +19,13 @@ import (
 )
 
 const (
-	host                  = "https://api.openai.com"
-	textGenerationTask    = "TASK_TEXT_GENERATION"
-	textEmbeddingsTask    = "TASK_TEXT_EMBEDDINGS"
-	speechRecognitionTask = "TASK_SPEECH_RECOGNITION"
-	textToSpeechTask      = "TASK_TEXT_TO_SPEECH"
-	textToImageTask       = "TASK_TEXT_TO_IMAGE"
+	host = "https://api.openai.com"
+
+	TextGenerationTask    = "TASK_TEXT_GENERATION"
+	TextEmbeddingsTask    = "TASK_TEXT_EMBEDDINGS"
+	SpeechRecognitionTask = "TASK_SPEECH_RECOGNITION"
+	TextToSpeechTask      = "TASK_TEXT_TO_SPEECH"
+	TextToImageTask       = "TASK_TEXT_TO_IMAGE"
 
 	cfgAPIKey       = "api_key"
 	cfgOrganization = "organization"
@@ -147,8 +148,8 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 
 	for _, input := range inputs {
 		switch e.Task {
-		case textGenerationTask:
-			inputStruct := textCompletionInput{}
+		case TextGenerationTask:
+			inputStruct := TextCompletionInput{}
 			err := base.ConvertFromStructpb(input, &inputStruct)
 			if err != nil {
 				return nil, err
@@ -212,7 +213,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 				return inputs, err
 			}
 
-			outputStruct := textCompletionOutput{
+			outputStruct := TextCompletionOutput{
 				Texts: []string{},
 				Usage: resp.Usage,
 			}
@@ -231,7 +232,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 			}
 			outputs = append(outputs, &output)
 
-		case textEmbeddingsTask:
+		case TextEmbeddingsTask:
 			inputStruct := TextEmbeddingsInput{}
 			err := base.ConvertFromStructpb(input, &inputStruct)
 			if err != nil {
@@ -258,7 +259,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 			}
 			outputs = append(outputs, output)
 
-		case speechRecognitionTask:
+		case SpeechRecognitionTask:
 			inputStruct := AudioTranscriptionInput{}
 			err := base.ConvertFromStructpb(input, &inputStruct)
 			if err != nil {
@@ -293,7 +294,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 			}
 			outputs = append(outputs, output)
 
-		case textToSpeechTask:
+		case TextToSpeechTask:
 			inputStruct := TextToSpeechInput{}
 			err := base.ConvertFromStructpb(input, &inputStruct)
 			if err != nil {
@@ -324,7 +325,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 			}
 			outputs = append(outputs, output)
 
-		case textToImageTask:
+		case TextToImageTask:
 
 			inputStruct := ImagesGenerationInput{}
 			err := base.ConvertFromStructpb(input, &inputStruct)

--- a/pkg/connector/openai/v0/text_generation.go
+++ b/pkg/connector/openai/v0/text_generation.go
@@ -9,7 +9,7 @@ type textMessage struct {
 	Content []content `json:"content"`
 }
 
-type textCompletionInput struct {
+type TextCompletionInput struct {
 	Prompt           string                `json:"prompt"`
 	Images           []string              `json:"images"`
 	ChatHistory      []*textMessage        `json:"chat_history,omitempty"`
@@ -29,7 +29,7 @@ type responseFormatStruct struct {
 	Type string `json:"type,omitempty"`
 }
 
-type textCompletionOutput struct {
+type TextCompletionOutput struct {
 	Texts []string `json:"texts"`
 	Usage usage    `json:"usage"`
 }


### PR DESCRIPTION
Because

- Usage handlers need to parse the input and output structures to collect e.g. token usage.

This commit

- Expose required structs and constants as exported.
