### PR TITLE
feat: add global secrets to StabilityAI connector

### DIFF
--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -3,6 +3,7 @@ package base
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
@@ -303,4 +304,20 @@ func (e *ConnectorExecution) UsesSecret() bool {
 // UsageHandlerCreator returns a function to initialize a UsageHandler.
 func (e *ConnectorExecution) UsageHandlerCreator() UsageHandlerCreator {
 	return e.Connector.UsageHandlerCreator()
+}
+
+// ReadFromSecrets reads a component secret from a secret map that comes from
+// environment variable configuration.
+//
+// Connection parameters are defined with snake_case, but the
+// environment variable configuration loader replaces underscores by dots,
+// so we can't use the parameter key directly.
+// TODO using camelCase in configuration fields would fix this issue.
+func ReadFromSecrets(key string, secrets map[string]any) string {
+	sanitized := strings.ReplaceAll(key, "_", "")
+	if v, ok := secrets[sanitized].(string); ok {
+		return v
+	}
+
+	return ""
 }

--- a/pkg/connector/main.go
+++ b/pkg/connector/main.go
@@ -65,7 +65,16 @@ func Init(
 			connectorIDMap:  map[string]*connector{},
 		}
 
-		conStore.Import(stabilityai.Init(baseConn))
+		{
+			// StabilityAI
+			conn := stabilityai.Init(baseConn)
+
+			// Secret doesn't allow hyphens
+			conn = conn.WithSecrets(secrets["stabilityai"]).
+				WithUsageHandlerCreator(usageHandlerCreators[conn.GetID()])
+			conStore.Import(conn)
+		}
+
 		conStore.Import(instill.Init(baseConn))
 		conStore.Import(huggingface.Init(baseConn))
 

--- a/pkg/connector/openai/v0/main.go
+++ b/pkg/connector/openai/v0/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -64,22 +63,10 @@ func Init(bc base.Connector) *Connector {
 	return con
 }
 
-// The connection parameter is defined with snake_case, but the
-// environment variable configuration loader replaces underscores by dots,
-// so we can't use the parameter key directly.
-func readFromSecrets(key string, s map[string]any) string {
-	sanitized := strings.ReplaceAll(key, "_", "")
-	if v, ok := s[sanitized].(string); ok {
-		return v
-	}
-
-	return ""
-}
-
 // WithSecrets loads secrets into the connector, which can be used to configure
 // it with globaly defined parameters.
 func (c *Connector) WithSecrets(s map[string]any) *Connector {
-	c.secretAPIKey = readFromSecrets(cfgAPIKey, s)
+	c.secretAPIKey = base.ReadFromSecrets(cfgAPIKey, s)
 
 	return c
 }

--- a/pkg/connector/stabilityai/v0/client.go
+++ b/pkg/connector/stabilityai/v0/client.go
@@ -24,3 +24,21 @@ type errBody struct {
 func (e errBody) Message() string {
 	return e.Msg
 }
+
+// getBasePath returns Stability AI's API URL. This configuration param allows
+// us to override the API the connector will point to. It isn't meant to be
+// exposed to users. Rather, it can serve to test the logic against a fake
+// server.
+// TODO instead of having the API value hardcoded in the codebase, it should be
+// read from a config file or environment variable.
+func getBasePath(config *structpb.Struct) string {
+	v, ok := config.GetFields()["base_path"]
+	if !ok {
+		return host
+	}
+	return v.GetStringValue()
+}
+
+func getAPIKey(config *structpb.Struct) string {
+	return config.GetFields()[cfgAPIKey].GetStringValue()
+}

--- a/pkg/connector/stabilityai/v0/connector_test.go
+++ b/pkg/connector/stabilityai/v0/connector_test.go
@@ -97,7 +97,7 @@ func TestConnector_ExecuteImageFromText(t *testing.T) {
 			})
 			c.Assert(err, qt.IsNil)
 
-			exec, err := connector.CreateExecution(nil, connection, textToImageTask)
+			exec, err := connector.CreateExecution(nil, connection, TextToImageTask)
 			c.Assert(err, qt.IsNil)
 
 			weights := []float64{weight}
@@ -192,7 +192,7 @@ func TestConnector_ExecuteImageFromImage(t *testing.T) {
 			})
 			c.Assert(err, qt.IsNil)
 
-			exec, err := connector.CreateExecution(nil, connection, imageToImageTask)
+			exec, err := connector.CreateExecution(nil, connection, ImageToImageTask)
 			c.Assert(err, qt.IsNil)
 
 			weights := []float64{weight}


### PR DESCRIPTION
Because

- We want to support global secrets on StabilityAI

This commit

- Adds global secrets and usage handler on StabilityAI
