### PR TITLE
feat: update Instill Credit supported model list

### DIFF
--- a/pkg/connector/openai/v0/config/tasks.json
+++ b/pkg/connector/openai/v0/config/tasks.json
@@ -135,6 +135,15 @@
           ],
           "instillShortDescription": "ID of the model to use",
           "instillUIOrder": 0,
+          "instillCredentialMap": {
+            "values": [
+              "text-embedding-3-small",
+              "text-embedding-3-large"
+            ],
+            "targets": [
+              "connection.api_key"
+            ]
+          },
           "instillUpstreamTypes": [
             "value",
             "reference",

--- a/pkg/connector/stabilityai/v0/config/definition.json
+++ b/pkg/connector/stabilityai/v0/config/definition.json
@@ -23,6 +23,7 @@
             "string"
           ],
           "instillSecret": true,
+          "instillCredential": true,
           "instillUIOrder": 0,
           "title": "API Key",
           "type": "string"

--- a/pkg/connector/stabilityai/v0/config/tasks.json
+++ b/pkg/connector/stabilityai/v0/config/tasks.json
@@ -284,6 +284,15 @@
             "stable-diffusion-512-v2-1",
             "stable-diffusion-xl-beta-v2-2-2"
           ],
+          "instillCredentialMap": {
+            "values": [
+              "stable-diffusion-xl-1024-v1-0",
+              "stable-diffusion-v1-6"
+            ],
+            "targets": [
+              "connection.api_key"
+            ]
+          },
           "instillAcceptFormats": [
             "string"
           ],


### PR DESCRIPTION
Because

- We'll support Instill Secrets for OpenAI test_embedding and StabilityAI text_to_image.

This commit

- Updates Instill Secrets supported model list.
