### PR TITLE
chore: add error to UsageHandlerCreator interface

### DIFF
--- a/pkg/base/execution.go
+++ b/pkg/base/execution.go
@@ -123,7 +123,11 @@ func (e *ExecutionWrapper) Execute(ctx context.Context, inputs []*structpb.Struc
 	}
 
 	newUH := e.Execution.UsageHandlerCreator()
-	h := newUH(e.Execution)
+	h, err := newUH(e.Execution)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := h.Check(ctx, inputs); err != nil {
 		return nil, err
 	}

--- a/pkg/base/usage.go
+++ b/pkg/base/usage.go
@@ -14,7 +14,7 @@ type UsageHandler interface {
 }
 
 // UsageHandlerCreator returns a function to initialize a UsageHandler.
-type UsageHandlerCreator func(IExecution) UsageHandler
+type UsageHandlerCreator func(IExecution) (UsageHandler, error)
 
 type noopUsageHandler struct{}
 
@@ -24,6 +24,6 @@ func (h *noopUsageHandler) Collect(_ context.Context, _, _ []*structpb.Struct) e
 }
 
 // NewNoopUsageHandler is a no-op usage handler initializer.
-func NewNoopUsageHandler(IExecution) UsageHandler {
-	return new(noopUsageHandler)
+func NewNoopUsageHandler(IExecution) (UsageHandler, error) {
+	return new(noopUsageHandler), nil
 }

--- a/pkg/connector/openai/v0/connector_test.go
+++ b/pkg/connector/openai/v0/connector_test.go
@@ -354,6 +354,6 @@ type usageHandlerCreator struct {
 	uh base.UsageHandler
 }
 
-func (c usageHandlerCreator) newUH(base.IExecution) base.UsageHandler {
-	return c.uh
+func (c usageHandlerCreator) newUH(base.IExecution) (base.UsageHandler, error) {
+	return c.uh, nil
 }


### PR DESCRIPTION
Because

- Some errors when creating a usage handler come from validating the execution.
  We don't need to wait for the `Check` / `Collect` methods in order to detect
  them.

This commit

- Adds an error to the `UsageHandlerCreator` interface
