### PR TITLE
feat(openai): support gpt-4o model

### DIFF
--- a/pkg/connector/openai/v0/config/openai.json
+++ b/pkg/connector/openai/v0/config/openai.json
@@ -1039,6 +1039,10 @@
           "model": {
             "description": "ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.",
             "enum": [
+              "gpt-4o",
+              "gpt-4o-2024-05-13",
+              "gpt-4-turbo",
+              "gpt-4-turbo-2024-04-09",
               "gpt-4-0125-preview",
               "gpt-4-turbo-preview",
               "gpt-4-1106-preview",
@@ -1054,6 +1058,7 @@
               "gpt-3.5-turbo-0301",
               "gpt-3.5-turbo-0613",
               "gpt-3.5-turbo-1106",
+              "gpt-3.5-turbo-0125",
               "gpt-3.5-turbo-16k-0613"
             ],
             "example": "gpt-3.5-turbo",

--- a/pkg/connector/openai/v0/config/tasks.json
+++ b/pkg/connector/openai/v0/config/tasks.json
@@ -271,7 +271,8 @@
           ],
           "instillCredentialMap": {
             "values": [
-              "gpt-4-turbo-preview",
+              "gpt-4o",
+              "gpt-4-turbo",
               "gpt-4-vision-preview",
               "gpt-4",
               "gpt-4-32k",


### PR DESCRIPTION
Because

- OpenAI has released new gpt-4o model.

This commit

- Adds gpt-4o and gpt-4-turbo model into model list.
