### PR TITLE
chore: extract duration from speech recognition

### DIFF
--- a/pkg/connector/openai/v0/audio_transcriptions.go
+++ b/pkg/connector/openai/v0/audio_transcriptions.go
@@ -21,15 +21,17 @@ type AudioTranscriptionInput struct {
 }
 
 type AudioTranscriptionReq struct {
-	File        []byte   `json:"file"`
-	Model       string   `json:"model"`
-	Prompt      *string  `json:"prompt,omitempty"`
-	Language    *string  `json:"language,omitempty"`
-	Temperature *float64 `json:"temperature,omitempty"`
+	File           []byte   `json:"file"`
+	Model          string   `json:"model"`
+	Prompt         *string  `json:"prompt,omitempty"`
+	Language       *string  `json:"language,omitempty"`
+	Temperature    *float64 `json:"temperature,omitempty"`
+	ResponseFormat string   `json:"response_format,omitempty"`
 }
 
 type AudioTranscriptionResp struct {
-	Text string `json:"text"`
+	Text     string  `json:"text"`
+	Duration float32 `json:"duration"`
 }
 
 func getBytes(req AudioTranscriptionReq) (*bytes.Reader, string, error) {
@@ -40,6 +42,7 @@ func getBytes(req AudioTranscriptionReq) (*bytes.Reader, string, error) {
 		return nil, "", err
 	}
 	util.WriteField(writer, "model", req.Model)
+	util.WriteField(writer, "response_format", req.ResponseFormat)
 	if req.Prompt != nil {
 		util.WriteField(writer, "prompt", *req.Prompt)
 	}

--- a/pkg/connector/openai/v0/main.go
+++ b/pkg/connector/openai/v0/main.go
@@ -264,6 +264,9 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 				Prompt:      inputStruct.Prompt,
 				Language:    inputStruct.Prompt,
 				Temperature: inputStruct.Temperature,
+
+				// Verbosity is passed to extract result duration.
+				ResponseFormat: "verbose_json",
 			})
 			if err != nil {
 				return inputs, err


### PR DESCRIPTION
Because

- Credit collection for speech recognition requires input audio duration.

This commit

- Calls OpenAI's speech recognition with the [`verbose_json`](https://github.com/openai/openai-openapi/blob/master/openapi.yaml#L8942) flag and sets the duration in the output.
  - Duration isn't part of the schema, so the executor's usage handler can read it but it won't be part of the UI.
