### PR TITLE
ci(Makefile): add test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ gen-doc:
 	@rm -f $$(find . -name README.mdx | paste -d ' ' -s -)
 	@go generate -run compogen ./...
 
-# install tesseract via brew install tesseract
 test:
+# Install tesseract via `brew install tesseract`
+# Setup `export LIBRARY_PATH="/opt/homebrew/lib"` `export CPATH="/opt/homebrew/include"`
 ifeq ($(shell uname), Darwin)
 	@TESSDATA_PREFIX=$(shell dirname $(shell brew list tesseract | grep share/tessdata/eng.traineddata)) go test ./... -tags ocr
 else

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 build-doc:
-	go install github.com/instill-ai/component/tools/compogen@latest
+	@go install github.com/instill-ai/component/tools/compogen@latest
 
 gen-doc:
 	@rm -f $$(find . -name README.mdx | paste -d ' ' -s -)
 	@go generate -run compogen ./...
+
+# install tesseract via brew install tesseract
+test:
+ifeq ($(shell uname), Darwin)
+	@TESSDATA_PREFIX=$(shell dirname $(shell brew list tesseract | grep share/tessdata/eng.traineddata)) go test ./... -tags ocr
+else
+	@echo "This target can only be executed on Darwin (macOS)."
+endif


### PR DESCRIPTION
Because

- local unit testing is essential while running `go test ./...` currently requires a `-tag ocr` due to the [docconv](https://github.com/sajari/docconv) package using [tesseract](https://tesseract-ocr.github.io)

This commit

- add `make test`
