### PR TITLE
chore: optimize GetConnectorDefinition

### DIFF
--- a/pkg/connector/instill/v0/main.go
+++ b/pkg/connector/instill/v0/main.go
@@ -188,6 +188,9 @@ func (c *connector) GetConnectorDefinition(sysVars map[string]any, component *pi
 	if err != nil {
 		return nil, err
 	}
+	if sysVars == nil && component == nil {
+		return oriDef, nil
+	}
 	def := proto.Clone(oriDef).(*pipelinePB.ConnectorDefinition)
 
 	if getModelServerURL(sysVars) == "" {

--- a/pkg/connector/restapi/v0/main.go
+++ b/pkg/connector/restapi/v0/main.go
@@ -172,6 +172,9 @@ func (c *connector) GetConnectorDefinition(sysVars map[string]any, component *pi
 	if err != nil {
 		return nil, err
 	}
+	if sysVars == nil && component == nil {
+		return oriDef, nil
+	}
 
 	def := proto.Clone(oriDef).(*pipelinePB.ConnectorDefinition)
 	if component == nil {


### PR DESCRIPTION
Because

- We can skip the dynamic component definition generation if the params are empty. 

This commit

- Optimizes `GetConnectorDefinition()` for the rest and Instill connector.