### PR TITLE
ci(github): change PR auto-label to instill component

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-instill vdp:
+instill component:
   - "**"


### PR DESCRIPTION
Because

- Instill Component is now a new product category to delimit Instill VDP

This commit

- change PR auto-label