### PR TITLE
chore: update document to lead the users to get Slack token

### DIFF
--- a/pkg/connector/pinecone/v0/README.mdx
+++ b/pkg/connector/pinecone/v0/README.mdx
@@ -23,8 +23,8 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api_key` | string | Fill your Pinecone AI API key. You can create a api key in [Pinecone Console](https://app.pinecone.io/) |
-| Pinecone Base URL (required) | `url` | string | Fill in your Pinecone base URL. It is in the form [https://index_name-project_id.svc.environment.pinecone.io] |
+| API Key (required) | `api_key` | string | Fill your Pinecone AI API key. You can create a api key in Pinecone Console |
+| Pinecone Base URL (required) | `url` | string | Fill in your Pinecone base URL. It is in the form |
 
 ## Supported Tasks
 

--- a/pkg/connector/pinecone/v0/config/definition.json
+++ b/pkg/connector/pinecone/v0/config/definition.json
@@ -15,7 +15,7 @@
       "additionalProperties": false,
       "properties": {
         "api_key": {
-          "description": "Fill your Pinecone AI API key. You can create a api key in [Pinecone Console](https://app.pinecone.io/)",
+          "description": "Fill your Pinecone AI API key. You can create a api key in Pinecone Console",
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -28,7 +28,7 @@
           "type": "string"
         },
         "url": {
-          "description": "Fill in your Pinecone base URL. It is in the form [https://index_name-project_id.svc.environment.pinecone.io]",
+          "description": "Fill in your Pinecone base URL. It is in the form",
           "instillUpstreamTypes": [
             "value"
           ],

--- a/pkg/connector/slack/v0/README.mdx
+++ b/pkg/connector/slack/v0/README.mdx
@@ -23,7 +23,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| token (required) | `token` | string | Please follow this [Slack tutorial](https://api.slack.com/tutorials/tracks/posting-messages-with-curl) to create a Slack app, set the scope of tokens, and get the token. |
+| token (required) | `token` | string | Please go to the Slack API tutorial to create a Slack App, set the scope of token, and get the token. |
 
 ## Supported Tasks
 

--- a/pkg/connector/slack/v0/README.mdx
+++ b/pkg/connector/slack/v0/README.mdx
@@ -23,7 +23,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| token (required) | `token` | string | Please go to the Slack API tutorial to create a Slack App, set the scope of token, and get the token. |
+| Token (required) | `token` | string | Fill in your Slack app access token. For more information about how to access to create app tokens, please refer to the Slack API documentation. |
 
 ## Supported Tasks
 

--- a/pkg/connector/slack/v0/README.mdx
+++ b/pkg/connector/slack/v0/README.mdx
@@ -23,7 +23,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| token (required) | `token` | string | 1. Go to [Slack API](https://api.slack.com/apps) and create a new app. 2. After creating a new app, go to the OAuth & Permissions page by clicking the app name. 3. Set the scope for the App.   - For reading messages, you need to set the scope to `channels:history` and `channels:read`.   - For sending messages, you need to set the scope to `chat:write`. 4. After setting the scope of App, you need to do 'Reinstall to Workspace'. 5. Go to the OAuth & Permissions page and copy the token.   - You will have 2 tokens, one for Bot User OAuth Token and another for User OAuth Token. You can use either of them.     - If you want to send a message to a channel by a bot, you should use Bot User OAuth Token, which is the token with the prefix of `xoxb-`.     - If you want to send a message to a channel by a user, you should use User OAuth Token, which is the token with the prefix of `xoxp-`.     - If you use Bot User OAuth Token, you need to invite the bot to the channel you want to read a message. |
+| token (required) | `token` | string | Please follow this [Slack tutorial](https://api.slack.com/tutorials/tracks/posting-messages-with-curl) to create a Slack app, set the scope of tokens, and get the token. |
 
 ## Supported Tasks
 

--- a/pkg/connector/slack/v0/README.mdx
+++ b/pkg/connector/slack/v0/README.mdx
@@ -23,7 +23,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| token | `token` | string | Fill your token |
+| token (required) | `token` | string | 1. Go to [Slack API](https://api.slack.com/apps) and create a new app. 2. After creating a new app, go to the OAuth & Permissions page by clicking the app name. 3. Set the scope for the App.   - For reading messages, you need to set the scope to `channels:history` and `channels:read`.   - For sending messages, you need to set the scope to `chat:write`. 4. After setting the scope of App, you need to do 'Reinstall to Workspace'. 5. Go to the OAuth & Permissions page and copy the token.   - You will have 2 tokens, one for Bot User OAuth Token and another for User OAuth Token. You can use either of them.     - If you want to send a message to a channel by a bot, you should use Bot User OAuth Token, which is the token with the prefix of `xoxb-`.     - If you want to send a message to a channel by a user, you should use User OAuth Token, which is the token with the prefix of `xoxp-`.     - If you use Bot User OAuth Token, you need to invite the bot to the channel you want to read a message. |
 
 ## Supported Tasks
 

--- a/pkg/connector/slack/v0/config/definition.json
+++ b/pkg/connector/slack/v0/config/definition.json
@@ -15,7 +15,7 @@
       "additionalProperties": false,
       "properties": {
         "token": {
-          "description": "Please go to the Slack API tutorial to create a Slack App, set the scope of token, and get the token.",
+          "description": "Fill in your Slack app access token. For more information about how to access to create app tokens, please refer to the Slack API documentation.",
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -24,7 +24,7 @@
           ],
           "instillSecret": true,
           "instillUIOrder": 0,
-          "title": "token",
+          "title": "Token",
           "type": "string"
         }
       },

--- a/pkg/connector/slack/v0/config/definition.json
+++ b/pkg/connector/slack/v0/config/definition.json
@@ -15,7 +15,7 @@
       "additionalProperties": false,
       "properties": {
         "token": {
-          "description": "Please follow this [Slack tutorial](https://api.slack.com/tutorials/tracks/posting-messages-with-curl) to create a Slack app, set the scope of tokens, and get the token.",
+          "description": "Please go to the Slack API tutorial to create a Slack App, set the scope of token, and get the token.",
           "instillUpstreamTypes": [
             "reference"
           ],

--- a/pkg/connector/slack/v0/config/definition.json
+++ b/pkg/connector/slack/v0/config/definition.json
@@ -15,7 +15,7 @@
       "additionalProperties": false,
       "properties": {
         "token": {
-          "description": "Fill your token",
+          "description": "1. Go to [Slack API](https://api.slack.com/apps) and create a new app. 2. After creating a new app, go to the OAuth & Permissions page by clicking the app name. 3. Set the scope for the App.   - For reading messages, you need to set the scope to `channels:history` and `channels:read`.   - For sending messages, you need to set the scope to `chat:write`. 4. After setting the scope of App, you need to do 'Reinstall to Workspace'. 5. Go to the OAuth & Permissions page and copy the token.   - You will have 2 tokens, one for Bot User OAuth Token and another for User OAuth Token. You can use either of them.     - If you want to send a message to a channel by a bot, you should use Bot User OAuth Token, which is the token with the prefix of `xoxb-`.     - If you want to send a message to a channel by a user, you should use User OAuth Token, which is the token with the prefix of `xoxp-`.     - If you use Bot User OAuth Token, you need to invite the bot to the channel you want to read a message.",
           "instillUpstreamTypes": [
             "reference"
           ],

--- a/pkg/connector/slack/v0/config/definition.json
+++ b/pkg/connector/slack/v0/config/definition.json
@@ -15,7 +15,7 @@
       "additionalProperties": false,
       "properties": {
         "token": {
-          "description": "1. Go to [Slack API](https://api.slack.com/apps) and create a new app. 2. After creating a new app, go to the OAuth & Permissions page by clicking the app name. 3. Set the scope for the App.   - For reading messages, you need to set the scope to `channels:history` and `channels:read`.   - For sending messages, you need to set the scope to `chat:write`. 4. After setting the scope of App, you need to do 'Reinstall to Workspace'. 5. Go to the OAuth & Permissions page and copy the token.   - You will have 2 tokens, one for Bot User OAuth Token and another for User OAuth Token. You can use either of them.     - If you want to send a message to a channel by a bot, you should use Bot User OAuth Token, which is the token with the prefix of `xoxb-`.     - If you want to send a message to a channel by a user, you should use User OAuth Token, which is the token with the prefix of `xoxp-`.     - If you use Bot User OAuth Token, you need to invite the bot to the channel you want to read a message.",
+          "description": "Please follow this [Slack tutorial](https://api.slack.com/tutorials/tracks/posting-messages-with-curl) to create a Slack app, set the scope of tokens, and get the token.",
           "instillUpstreamTypes": [
             "reference"
           ],


### PR DESCRIPTION
Because

- Slack token document is unclear for users

This commit

- Add the instruction.
- Note: please check the reference in [Linear](https://linear.app/instill-ai/issue/INS-4686/improve-slack-document#comment-85d32dd7)
