### PR TITLE
fix: bug of failure of document component

### DIFF
--- a/operator/document/v0/convert_pdf_to_markdown.go
+++ b/operator/document/v0/convert_pdf_to_markdown.go
@@ -32,10 +32,10 @@ func convertPDFToMarkdown(input convertPDFToMarkdownInput, cmdRunner commandRunn
 	if err != nil {
 		return convertPDFToMarkdownOutput{}, err
 	}
-	defer stdin.Close()
 	errChan := make(chan error, 1)
 
 	go func() {
+		defer stdin.Close()
 		_, err := stdin.Write(b)
 		if err != nil {
 			errChan <- err


### PR DESCRIPTION
Because

- the stdin in a thread is not closed, so the pipeline stuck.

This commit

- fix the sequence of close of stdin
