### PR TITLE
feat: use camelCase in JSON files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -275,11 +275,11 @@ component.
 
 ```json
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_GREET"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/operator/hello",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/hello",
   "icon": "assets/hello.svg",
   "id": "hello",
   "public": true,
@@ -287,9 +287,9 @@ component.
   "title": "Hello",
   "uid": "e05d3d71-779c-45f8-904d-e90a050ca3b2",
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/operator/hello/v0",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/hello/v0",
   "description": "'Hello, world' operator used as a template for adding components",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }
 ```
 
@@ -304,21 +304,21 @@ This file defines the component properties:
 - **`spec`** contains the parameters required to configure the component and
   that are independent from its tasks. E.g., the API token of a vendor. In
   general, only AI, data or application components need such parameters.
-- **`available_tasks`** defines the tasks the component can perform.
+- **`availableTasks`** defines the tasks the component can perform.
   - When a component is created in a pipeline, one of the tasks has to be
     selected, i.e., a configured component can only execute one task.
   - Task configurations are defined in `tasks.json`.
-- **`documentation_url`** points to the official documentation of the component.
+- **`documentationUrl`** points to the official documentation of the component.
 - **`icon`** is the local path to the icon that will be displayed in the Console
   when creating the component. If left blank, a placeholder icon will be shown.
 - **`version`** must be a [SemVer](https://semver.org/) string. It is encouraged
   to keep a [tidy version history](#sane-version-control).
-- **`source_url`** points to the codebase that implements the component. This
+- **`sourceUrl`** points to the codebase that implements the component. This
   will be used by the documentation generation tool and also will be part of the
   [component definition
   list](https://openapi.instill.tech/reference/pipelinepublicservice_listcomponentdefinitions)
   endpoint.
-- **`release_stage`** describes the release stage of the component.
+- **`releaseStage`** describes the release stage of the component.
   Unimplemented stages (`RELEASE_STAGE_COMING_SOON` or
   `RELEASE_STAGE_OPEN_FOR_CONTRIBUTION`) will hide the component from the
   console (i.e. they can't be used in pipelines) but they will appear in the
@@ -771,7 +771,7 @@ Semantic Versioning guidelines.
 It is recommended to start a component at `v0.1.0`. A major version 0 is
 intended for rapid development.
 
-The `release_stage` property in `definition.json` indicates the stability of a
+The `releaseStage` property in `definition.json` indicates the stability of a
 component.
 
 - A component skeleton (with only the minimal configuration files and a dummy

--- a/ai/archetypeai/v0/config/definition.json
+++ b/ai/archetypeai/v0/config/definition.json
@@ -1,13 +1,13 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_DESCRIBE",
     "TASK_SUMMARIZE",
     "TASK_UPLOAD_FILE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/ai/archetypeai",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/archetypeai",
   "icon": "assets/archetype-ai.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "archetype-ai",
   "public": true,
   "title": "Archetype AI",
@@ -16,8 +16,8 @@
   "type": "COMPONENT_TYPE_AI",
   "uid": "e414a1f8-5fdf-4292-b050-9f9176254a4b",
   "vendor": "Archetype AI",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/ai/archetypeai/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/ai/archetypeai/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/ai/huggingface/v0/config/definition.json
+++ b/ai/huggingface/v0/config/definition.json
@@ -1,5 +1,5 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_TEXT_GENERATION",
     "TASK_FILL_MASK",
     "TASK_SUMMARIZATION",
@@ -19,9 +19,9 @@
     "TASK_AUDIO_CLASSIFICATION"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/ai/huggingface",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/huggingface",
   "icon": "assets/hugging-face.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "hugging-face",
   "public": true,
   "title": "Hugging Face",
@@ -30,8 +30,8 @@
   "type": "COMPONENT_TYPE_AI",
   "uid": "0255ef87-33ce-4f88-b9db-8897f8c17233",
   "vendor": "Hugging Face",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/ai/huggingface/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/ai/huggingface/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/ai/instill/v0/config/definition.json
+++ b/ai/instill/v0/config/definition.json
@@ -1,5 +1,5 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_CLASSIFICATION",
     "TASK_INSTANCE_SEGMENTATION",
     "TASK_KEYPOINT",
@@ -13,9 +13,9 @@
     "TASK_IMAGE_TO_IMAGE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/ai/instill",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/instill",
   "icon": "assets/instill-model.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "instill-model",
   "public": true,
   "title": "Instill Model",
@@ -24,8 +24,8 @@
   "type": "COMPONENT_TYPE_AI",
   "uid": "ddcf42c3-4c30-4c65-9585-25f1c89b2b48",
   "vendor": "Instill",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/ai/instill/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/ai/instill/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/ai/openai/v0/config/definition.json
+++ b/ai/openai/v0/config/definition.json
@@ -1,5 +1,5 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_TEXT_GENERATION",
     "TASK_TEXT_EMBEDDINGS",
     "TASK_SPEECH_RECOGNITION",
@@ -9,7 +9,7 @@
   "custom": false,
   "documentation_url": "https://www.instill.tech/docs/component/ai/openai",
   "icon": "assets/openai.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "openai",
   "public": true,
   "title": "OpenAI",
@@ -17,8 +17,8 @@
   "type": "COMPONENT_TYPE_AI",
   "uid": "9fb6a2cb-bff5-4c69-bc6d-4538dd8e3362",
   "vendor": "OpenAI",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/ai/openai/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/ai/openai/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/ai/stabilityai/v0/config/definition.json
+++ b/ai/stabilityai/v0/config/definition.json
@@ -1,12 +1,12 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_TEXT_TO_IMAGE",
     "TASK_IMAGE_TO_IMAGE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/ai/stabilityai",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/stabilityai",
   "icon": "assets/stability-ai.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "stability-ai",
   "public": true,
   "title": "Stability AI",
@@ -15,8 +15,8 @@
   "type": "COMPONENT_TYPE_AI",
   "uid": "c86a95cc-7d32-4e22-a290-8c699f6705a4",
   "vendor": "Stability AI",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/ai/stabilityai/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/ai/stabilityai/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/application/googlesearch/v0/config/definition.json
+++ b/application/googlesearch/v0/config/definition.json
@@ -1,11 +1,11 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_SEARCH"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/application/googlesearch",
+  "documentationUrl": "https://www.instill.tech/docs/component/application/googlesearch",
   "icon": "assets/google-search.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "google-search",
   "public": true,
   "title": "Google Search",
@@ -14,8 +14,8 @@
   "type": "COMPONENT_TYPE_APPLICATION",
   "uid": "2b1da686-878a-462c-b2c6-a9690199939c",
   "vendor": "Google",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/application/googlesearch/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/application/googlesearch/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/application/numbers/v0/config/definition.json
+++ b/application/numbers/v0/config/definition.json
@@ -1,11 +1,11 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_REGISTER"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/application/numbers",
+  "documentationUrl": "https://www.instill.tech/docs/component/application/numbers",
   "icon": "assets/numbers.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "numbers",
   "public": true,
   "title": "Numbers Protocol",
@@ -14,8 +14,8 @@
   "type": "COMPONENT_TYPE_APPLICATION",
   "uid": "70d8664a-d512-4517-a5e8-5d4da81756a7",
   "vendor": "Numbers Protocol",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/application/numbers/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/application/numbers/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/application/restapi/v0/config/definition.json
+++ b/application/restapi/v0/config/definition.json
@@ -1,5 +1,5 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_GET",
     "TASK_POST",
     "TASK_PATCH",
@@ -9,9 +9,9 @@
     "TASK_OPTIONS"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/application/restapi",
+  "documentationUrl": "https://www.instill.tech/docs/component/application/restapi",
   "icon": "assets/restapi.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "restapi",
   "public": true,
   "title": "REST API",
@@ -20,8 +20,8 @@
   "type": "COMPONENT_TYPE_APPLICATION",
   "uid": "5ee55a5c-6e30-4c7a-80e8-90165a729e0a",
   "vendor": "",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/application/restapi/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/application/restapi/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/application/slack/v0/config/definition.json
+++ b/application/slack/v0/config/definition.json
@@ -1,12 +1,12 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_READ_MESSAGE",
     "TASK_WRITE_MESSAGE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/application/slack",
+  "documentationUrl": "https://www.instill.tech/docs/component/application/slack",
   "icon": "assets/slack.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "slack",
   "public": true,
   "title": "Slack",
@@ -15,8 +15,8 @@
   "type": "COMPONENT_TYPE_APPLICATION",
   "uid": "1e9f469e-da5e-46eb-8a89-23466627e3b5",
   "vendor": "Slack",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/application/slack/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/application/slack/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/application/website/v0/config/definition.json
+++ b/application/website/v0/config/definition.json
@@ -1,11 +1,11 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_SCRAPE_WEBSITE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/application/website",
+  "documentationUrl": "https://www.instill.tech/docs/component/application/website",
   "icon": "assets/website.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "website",
   "public": true,
   "title": "Website",
@@ -13,8 +13,8 @@
   "type": "COMPONENT_TYPE_APPLICATION",
   "uid": "98909958-db7d-4dfe-9858-7761904be17e",
   "vendor": "",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/application/website/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/application/website/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/base/component.go
+++ b/base/component.go
@@ -581,7 +581,7 @@ func (c *Component) LoadDefinition(definitionJSONBytes, setupJSONBytes, tasksJSO
 	}
 
 	availableTasks := []string{}
-	for _, availableTask := range definitionJSON.(map[string]interface{})["available_tasks"].([]interface{}) {
+	for _, availableTask := range definitionJSON.(map[string]interface{})["availableTasks"].([]interface{}) {
 		availableTasks = append(availableTasks, availableTask.(string))
 	}
 

--- a/base/component.go
+++ b/base/component.go
@@ -831,17 +831,7 @@ func ReadFromSecrets(key string, secrets map[string]any) string {
 }
 
 type ComponentConfig struct {
-	Type       string                  `json:"type,omitempty"`
-	Task       string                  `json:"task,omitempty"`
-	Input      map[string]any          `json:"input,omitempty"`
-	Condition  *string                 `json:"condition,omitempty"`
-	Setup      map[string]any          `json:"setup,omitempty"`
-	Metadata   map[string]any          `json:"metadata,omitempty"`
-	Definition *pb.ComponentDefinition `json:"definition,omitempty"`
-}
-
-func (c *ComponentConfig) IsComponent() {}
-
-func (c *ComponentConfig) GetCondition() *string {
-	return c.Condition
+	Task  string
+	Input map[string]any
+	Setup map[string]any
 }

--- a/base/component_test.go
+++ b/base/component_test.go
@@ -2,10 +2,12 @@ package base
 
 import (
 	_ "embed"
+	"encoding/json"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var (
@@ -38,5 +40,11 @@ func TestComponent_ListConnectorDefinitions(t *testing.T) {
 
 	got, err := conn.GetDefinition(nil, nil)
 	c.Assert(err, qt.IsNil)
-	c.Check(wantConnectorDefinitionJSON, qt.JSONEquals, got)
+	gotJSON, err := protojson.Marshal(got)
+	c.Assert(err, qt.IsNil)
+
+	wantConnectorDefinitionStruct := map[string]any{}
+	err = json.Unmarshal(wantConnectorDefinitionJSON, &wantConnectorDefinitionStruct)
+	c.Assert(err, qt.IsNil)
+	c.Check(gotJSON, qt.JSONEquals, wantConnectorDefinitionStruct)
 }

--- a/base/testdata/connectorDef.json
+++ b/base/testdata/connectorDef.json
@@ -1,11 +1,11 @@
 {
   "version": "1.0.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/base",
-  "available_tasks": [
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/base",
+  "availableTasks": [
     "TASK_TEXT_EMBEDDINGS"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/ai/openai",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/openai",
   "icon": "OpenAI/openai.svg",
   "id": "openai",
   "public": true,
@@ -13,5 +13,5 @@
   "type": "COMPONENT_TYPE_AI",
   "uid": "9fb6a2cb-bff5-4c69-bc6d-4538dd8e3362",
   "vendor": "OpenAI",
-  "vendor_attributes": {}
+  "vendorAttributes": {}
 }

--- a/base/testdata/operatorDef.json
+++ b/base/testdata/operatorDef.json
@@ -1,13 +1,13 @@
 {
   "version": "1.0.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/base",
-  "available_tasks": [
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/base",
+  "availableTasks": [
     "TASK_MARSHAL"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/operator/json",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/json",
   "icon": "Instill AI/json.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "json",
   "public": true,
   "spec": {},

--- a/base/testdata/wantConnectorDefinition.json
+++ b/base/testdata/wantConnectorDefinition.json
@@ -3,10 +3,10 @@
   "uid": "9fb6a2cb-bff5-4c69-bc6d-4538dd8e3362",
   "id": "openai",
   "title": "OpenAI",
-  "documentation_url": "https://www.instill.tech/docs/component/ai/openai",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/openai",
   "icon": "OpenAI/openai.svg",
   "spec": {
-    "component_specification": {
+    "componentSpecification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "oneOf": [
         {
@@ -134,7 +134,7 @@
       "title": "OpenAI Component",
       "type": "object"
     },
-    "data_specifications": {
+    "dataSpecifications": {
       "TASK_TEXT_EMBEDDINGS": {
         "input": {
           "instillEditOnNodeFields": [
@@ -194,10 +194,10 @@
       }
     }
   },
-  "type": 1,
+  "type": "COMPONENT_TYPE_AI",
   "public": true,
   "vendor": "OpenAI",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "tasks": [
     {
       "name": "TASK_TEXT_EMBEDDINGS",
@@ -206,5 +206,5 @@
     }
   ],
   "version": "1.0.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/base"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/base"
 }

--- a/base/testdata/wantOperatorDefinition.json
+++ b/base/testdata/wantOperatorDefinition.json
@@ -3,10 +3,10 @@
   "uid": "28f53d15-6150-46e6-99aa-f76b70a926c0",
   "id": "json",
   "title": "JSON",
-  "documentation_url": "https://www.instill.tech/docs/component/operator/json",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/json",
   "icon": "Instill AI/json.svg",
   "spec": {
-    "component_specification": {
+    "componentSpecification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "oneOf": [
         {
@@ -69,7 +69,7 @@
       "title": "JSON Component",
       "type": "object"
     },
-    "data_specifications": {
+    "dataSpecifications": {
       "TASK_MARSHAL": {
         "input": {
           "description": "Input",
@@ -128,7 +128,7 @@
   },
   "public": true,
   "version": "1.0.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/base",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/base",
   "tasks": [
     {
       "name": "TASK_MARSHAL",

--- a/data/bigquery/v0/config/definition.json
+++ b/data/bigquery/v0/config/definition.json
@@ -1,11 +1,11 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_INSERT"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/data/bigquery",
+  "documentationUrl": "https://www.instill.tech/docs/component/data/bigquery",
   "icon": "assets/bigquery.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "bigquery",
   "public": true,
   "title": "BigQuery",
@@ -14,8 +14,8 @@
   "type": "COMPONENT_TYPE_DATA",
   "uid": "e2ffe076-ab2c-4e5e-9587-a613a6b1c146",
   "vendor": "Google",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/data/bigquery/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/data/bigquery/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/data/googlecloudstorage/v0/config/definition.json
+++ b/data/googlecloudstorage/v0/config/definition.json
@@ -1,11 +1,11 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_UPLOAD"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/data/googlecloudstorage",
+  "documentationUrl": "https://www.instill.tech/docs/component/data/googlecloudstorage",
   "icon": "assets/gcs.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "gcs",
   "public": true,
   "title": "Google Cloud Storage",
@@ -14,8 +14,8 @@
   "type": "COMPONENT_TYPE_DATA",
   "uid": "205cbeff-6f45-4abe-b0a8-cec1a310137f",
   "vendor": "Google",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/data/googlecloudstorage/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/data/googlecloudstorage/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/data/pinecone/v0/config/definition.json
+++ b/data/pinecone/v0/config/definition.json
@@ -1,12 +1,12 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_QUERY",
     "TASK_UPSERT"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/data/pinecone",
+  "documentationUrl": "https://www.instill.tech/docs/component/data/pinecone",
   "icon": "assets/pinecone.svg",
-  "icon_url": "https://www.pinecone.io/favicon.ico",
+  "iconUrl": "https://www.pinecone.io/favicon.ico",
   "id": "pinecone",
   "public": true,
   "title": "Pinecone",
@@ -15,8 +15,8 @@
   "type": "COMPONENT_TYPE_DATA",
   "uid": "4b1dcf82-e134-4ba7-992f-f9a02536ec2b",
   "vendor": "Pinecone",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/data/pinecone/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/data/pinecone/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/data/redis/v0/config/definition.json
+++ b/data/redis/v0/config/definition.json
@@ -1,13 +1,13 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_RETRIEVE_CHAT_HISTORY",
     "TASK_WRITE_CHAT_MESSAGE",
     "TASK_WRITE_MULTI_MODAL_CHAT_MESSAGE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/data/redis",
+  "documentationUrl": "https://www.instill.tech/docs/component/data/redis",
   "icon": "assets/redis.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "redis",
   "public": true,
   "title": "Redis",
@@ -15,8 +15,8 @@
   "type": "COMPONENT_TYPE_DATA",
   "uid": "fd0ad325-f2f7-41f3-b247-6c71d571b1b8",
   "vendor": "Redis Labs",
-  "vendor_attributes": {},
+  "vendorAttributes": {},
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/data/redis/v0",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/data/redis/v0",
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/operator/base64/v0/config/definition.json
+++ b/operator/base64/v0/config/definition.json
@@ -1,12 +1,12 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_ENCODE",
     "TASK_DECODE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/operator/base64",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/base64",
   "icon": "assets/base64.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "base64",
   "public": true,
   "spec": {},
@@ -15,7 +15,7 @@
   "tombstone": false,
   "uid": "3a836447-c211-4134-9cc5-ad45e1cc467e",
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/operator/base64/v0",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/base64/v0",
   "description": "Encode or decode a string in Base64 format",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/operator/document/v0/config/definition.json
+++ b/operator/document/v0/config/definition.json
@@ -1,9 +1,9 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_CONVERT_TO_MARKDOWN"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/operator/document",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/document",
   "icon": "assets/document.svg",
   "id": "document",
   "public": true,
@@ -12,7 +12,7 @@
   "type": "COMPONENT_TYPE_OPERATOR",
   "uid": "e5b290ae-ad53-47c9-a64e-efbc5358520b",
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/operator/document/v0",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/document/v0",
   "description": "Manipulate Document files",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/operator/image/v0/config/definition.json
+++ b/operator/image/v0/config/definition.json
@@ -1,5 +1,5 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_DRAW_CLASSIFICATION",
     "TASK_DRAW_DETECTION",
     "TASK_DRAW_KEYPOINT",
@@ -8,9 +8,9 @@
     "TASK_DRAW_SEMANTIC_SEGMENTATION"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/operator/image",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/image",
   "icon": "assets/image.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "image",
   "public": true,
   "spec": {},
@@ -18,7 +18,7 @@
   "type": "COMPONENT_TYPE_OPERATOR",
   "uid": "e9eb8fc8-f249-4e11-ad50-5035d79ffc18",
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/operator/image/v0",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/image/v0",
   "description": "Manipulate image files",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/operator/json/v0/config/definition.json
+++ b/operator/json/v0/config/definition.json
@@ -1,13 +1,13 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_MARSHAL",
     "TASK_UNMARSHAL",
     "TASK_JQ"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/operator/json",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/json",
   "icon": "assets/json.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "json",
   "public": true,
   "spec": {},
@@ -15,7 +15,7 @@
   "type": "COMPONENT_TYPE_OPERATOR",
   "uid": "28f53d15-6150-46e6-99aa-f76b70a926c0",
   "version": "0.1.0",
-  "source_url": "https://github.com/instill-ai/component/blob/main/operator/json/v0",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/json/v0",
   "description": "Manipulate and convert JSON objects",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/operator/text/v0/config/definition.json
+++ b/operator/text/v0/config/definition.json
@@ -1,13 +1,13 @@
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_CONVERT_TO_TEXT",
     "TASK_SPLIT_BY_TOKEN",
     "TASK_CHUNK_TEXT"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/operator/text",
+  "documentationUrl": "https://www.instill.tech/docs/component/operator/text",
   "icon": "assets/text.svg",
-  "icon_url": "",
+  "iconUrl": "",
   "id": "text",
   "public": true,
   "spec": {},
@@ -15,7 +15,7 @@
   "type": "COMPONENT_TYPE_OPERATOR",
   "uid": "5b7aca5b-1ae3-477f-bf60-d34e1c993c87",
   "version": "0.1.1",
-  "source_url": "https://github.com/instill-ai/component/blob/main/operator/text/v0",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/text/v0",
   "description": "Extract and manipulate text from different sources",
-  "release_stage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/tools/compogen/README.md
+++ b/tools/compogen/README.md
@@ -33,14 +33,14 @@ following fields must be present and comply with the following guidelines:
 - `description` - It should contain a single sentence describing the component.
   The template will use it next to the component title (`{{ .Title }}{{
   .Description }}.`) so it must be written in imperative tense.
-- `release_stage` - Must be the string representation of one of the nonzero
+- `releaseStage` - Must be the string representation of one of the nonzero
   values of `ComponentDefinition.ReleaseStage`,defined in
   [protobufs](https://github.com/instill-ai/protobufs/blob/main/vdp/pipeline/v1beta/component_definition.proto).
 - `type` - Component definitions must contain this field and its value must
   match one of the (string) values defined in [protobufs](https://github.com/instill-ai/protobufs/blob/main/vdp/pipeline/v1beta/component_definition.proto).
-- `available_tasks` - This array must have at least one value, which should be
+- `availableTasks` - This array must have at least one value, which should be
   one of the root-level keys in the `tasks.json` file.
-- `source_url` - Must be a valid URL. It must not end with a slash, as the
+- `sourceUrl` - Must be a valid URL. It must not end with a slash, as the
   definitions path will be appended.
 
 Certain optional fields modify the document behaviour:

--- a/tools/compogen/cmd/testdata/readme-connector.txt
+++ b/tools/compogen/cmd/testdata/readme-connector.txt
@@ -12,7 +12,7 @@ cmp pkg/dummy/README.mdx want-readme.mdx
 
 -- definition.json --
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_DUMMY"
   ],
   "public": true,
@@ -21,8 +21,8 @@ cmp pkg/dummy/README.mdx want-readme.mdx
   "description": "Perform an action",
   "prerequisites": "An account at [dummy.io](https://dummy.io) is required.",
   "type": "COMPONENT_TYPE_DATA",
-  "release_stage": "RELEASE_STAGE_COMING_SOON",
-  "source_url": "https://github.com/instill-ai/component/blob/main/data/dummy/v0"
+  "releaseStage": "RELEASE_STAGE_COMING_SOON",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/data/dummy/v0"
 }
 
 -- setup.json --

--- a/tools/compogen/cmd/testdata/readme-operator.txt
+++ b/tools/compogen/cmd/testdata/readme-operator.txt
@@ -24,7 +24,7 @@ cmp pkg/dummy/README.mdx want-readme.mdx
 
 -- definition.json --
 {
-  "available_tasks": [
+  "availableTasks": [
     "TASK_DUMMY",
     "TASK_DUMMIER_THAN_DUMMY"
   ],
@@ -34,8 +34,8 @@ cmp pkg/dummy/README.mdx want-readme.mdx
   "title": "Dummy",
   "type": "COMPONENT_TYPE_OPERATOR",
   "description": "Perform an action",
-  "release_stage": "RELEASE_STAGE_BETA",
-  "source_url": "https://github.com/instill-ai/component/blob/main/operator/dummy/v0"
+  "releaseStage": "RELEASE_STAGE_BETA",
+  "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/dummy/v0"
 }
 -- tasks.json --
 {

--- a/tools/compogen/pkg/gen/definition.go
+++ b/tools/compogen/pkg/gen/definition.go
@@ -35,9 +35,9 @@ type definition struct {
 	ID             string       `json:"id" validate:"required"`
 	Title          string       `json:"title" validate:"required"`
 	Description    string       `json:"description" validate:"required"`
-	ReleaseStage   releaseStage `json:"release_stage" validate:"required"`
-	AvailableTasks []string     `json:"available_tasks" validate:"gt=0"`
-	SourceURL      string       `json:"source_url" validate:"url"`
+	ReleaseStage   releaseStage `json:"releaseStage" validate:"required"`
+	AvailableTasks []string     `json:"availableTasks" validate:"gt=0"`
+	SourceURL      string       `json:"sourceUrl" validate:"url"`
 
 	Public        bool   `json:"public"`
 	Type          string `json:"type"`

--- a/tools/compogen/pkg/gen/definition_test.go
+++ b/tools/compogen/pkg/gen/definition_test.go
@@ -118,7 +118,7 @@ func TestReleaseStage_UnmarshalAndStringify(t *testing.T) {
 	for _, tc := range testcases {
 		c.Run(tc.in, func(c *qt.C) {
 			def := definition{}
-			j := json.RawMessage(`{"release_stage": "` + tc.in + `"}`)
+			j := json.RawMessage(`{"releaseStage": "` + tc.in + `"}`)
 
 			err := json.Unmarshal(j, &def)
 			c.Check(err, qt.IsNil)


### PR DESCRIPTION
Because:

- Currently, our JSON files are a mix of camelCase, snake_case, and kebab-case, which is not consistent.

This commit:

- Uses camelCase in JSON files.
- Simplify `ComponentConfig` struct since most of the fields are not used in the component package.

Note:

- We don't change the JSON keys of `properties` in this PR. We'll use kebab-case for them and address this in another PR.