### PR TITLE
feat: add toggle image tag function for document pdf to markdown task

### DIFF
--- a/operator/document/v0/config/tasks.json
+++ b/operator/document/v0/config/tasks.json
@@ -20,6 +20,20 @@
           ],
           "title": "Document",
           "type": "string"
+        },
+        "display-image-tag": {
+          "description": "Choose if the result displays image tags",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "instillUIOrder": 1,
+          "title": "Display image tag",
+          "type": "boolean"
         }
       },
       "required": [

--- a/operator/document/v0/convert_pdf_to_markdown.go
+++ b/operator/document/v0/convert_pdf_to_markdown.go
@@ -1,7 +1,6 @@
 package document
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"io"
 
@@ -14,7 +13,8 @@ type commandRunner interface {
 }
 
 type convertPDFToMarkdownInput struct {
-	PDF string `json:"pdf"`
+	PDF             string `json:"pdf"`
+	DisplayImageTag bool   `json:"display-image-tag"`
 }
 
 type convertPDFToMarkdownOutput struct {
@@ -23,7 +23,11 @@ type convertPDFToMarkdownOutput struct {
 
 func convertPDFToMarkdown(input convertPDFToMarkdownInput, cmdRunner commandRunner) (convertPDFToMarkdownOutput, error) {
 
-	b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(input.PDF))
+	paramsJSON, err := json.Marshal(map[string]interface{}{
+		"PDF":               base.TrimBase64Mime(input.PDF),
+		"display-image-tag": input.DisplayImageTag,
+	})
+
 	if err != nil {
 		return convertPDFToMarkdownOutput{}, err
 	}
@@ -36,7 +40,7 @@ func convertPDFToMarkdown(input convertPDFToMarkdownInput, cmdRunner commandRunn
 
 	go func() {
 		defer stdin.Close()
-		_, err := stdin.Write(b)
+		_, err := stdin.Write(paramsJSON)
 		if err != nil {
 			errChan <- err
 			return

--- a/operator/document/v0/python/transformPDFToMarkdown.py
+++ b/operator/document/v0/python/transformPDFToMarkdown.py
@@ -2,9 +2,10 @@ import pdfplumber
 import sys
 from io import BytesIO
 import json
+import base64
 
 class PdfTransformer:
-	def __init__(self, x):
+	def __init__(self, x, display_image_tag=False):
 		# self.path = path
 		# x can be a path or a file object.
 		self.pdf = pdfplumber.open(x)
@@ -15,7 +16,9 @@ class PdfTransformer:
 		self.lines = []
 		self.tables = []
 		self.images = []
-		self.process_image()
+		if display_image_tag:
+			self.process_image()
+	
 		for page in self.pages:
 			page_lines = page.extract_text_lines()
 			self.process_line(page_lines, page.page_number)
@@ -302,9 +305,13 @@ class PdfTransformer:
 
 
 if __name__ == "__main__":
-	pdf_bytes = sys.stdin.buffer.read()
-	pdf_file_obj = BytesIO(pdf_bytes)
-	pdf = PdfTransformer(pdf_file_obj)
+	json_str = sys.stdin.buffer.read().decode('utf-8')
+	params = json.loads(json_str)
+	display_image_tag = params["display-image-tag"]
+	pdf_string = params["PDF"]
+	decoded_bytes = base64.b64decode(pdf_string)
+	pdf_file_obj = BytesIO(decoded_bytes)
+	pdf = PdfTransformer(pdf_file_obj, display_image_tag)
 	result = pdf.execute()
 	output = {
 		"body": result,


### PR DESCRIPTION
Because

- AI engineers want to exclude the image tag when they do not want to include them.

This commit

- Add toggle option in pdf to markdown task in document operator
