### PR TITLE
chore(instill): fix incorrect unmarshalling in Instill component

### DIFF
--- a/ai/instill/v0/image_classification.go
+++ b/ai/instill/v0/image_classification.go
@@ -22,17 +22,9 @@ func (e *execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
 
-		inputJSON, err := protojson.Marshal(input)
-		if err != nil {
-			return nil, err
-		}
 		classificationInput := &modelPB.ClassificationInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, classificationInput)
-		if err != nil {
-			return nil, err
-		}
 		classificationInput.Type = &modelPB.ClassificationInput_ImageBase64{
-			ImageBase64: base.TrimBase64Mime(classificationInput.GetImageBase64()),
+			ImageBase64: base.TrimBase64Mime(input.Fields["image-base64"].GetStringValue()),
 		}
 
 		taskInput := &modelPB.TaskInput_Classification{

--- a/ai/instill/v0/main.go
+++ b/ai/instill/v0/main.go
@@ -21,6 +21,9 @@ import (
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
+// TODO: The Instill Model component will be refactored soon to align the data
+// structure with Instill Model.
+
 var (
 	//go:embed config/definition.json
 	definitionJSON []byte

--- a/ai/instill/v0/semantic_segmentation.go
+++ b/ai/instill/v0/semantic_segmentation.go
@@ -19,17 +19,9 @@ func (e *execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 	}
 	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
-		inputJSON, err := protojson.Marshal(input)
-		if err != nil {
-			return nil, err
-		}
 		semanticSegmentationInput := &modelPB.SemanticSegmentationInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, semanticSegmentationInput)
-		if err != nil {
-			return nil, err
-		}
 		semanticSegmentationInput.Type = &modelPB.SemanticSegmentationInput_ImageBase64{
-			ImageBase64: base.TrimBase64Mime(semanticSegmentationInput.GetImageBase64()),
+			ImageBase64: base.TrimBase64Mime(input.Fields["image-base64"].GetStringValue()),
 		}
 
 		taskInput := &modelPB.TaskInput_SemanticSegmentation{


### PR DESCRIPTION
Because

- The unmarshalling in the Instill component is incorrect due to the recent refactor involving camelCase and kebab-case.

This commit

- Fixes the incorrect unmarshalling in the Instill component.

Note:

- We'll soon refactor the Instill Model component data format to align it with the data format in Instill Model, ensuring no differences in the future.