### PR TITLE
fix(redis): fix typo

### DIFF
--- a/data/redis/v0/config/definition.json
+++ b/data/redis/v0/config/definition.json
@@ -1,8 +1,8 @@
 {
   "availableTasks": [
     "TASK_RETRIEVE_CHAT_HISTORY",
-    "TASK_WRITE_chat-message",
-    "TASK_WRITE_MULTI_MODAL_chat-message"
+    "TASK_WRITE_CHAT_MESSAGE",
+    "TASK_WRITE_MULTI_MODAL_CHAT_MESSAGE"
   ],
   "custom": false,
   "documentationUrl": "https://www.instill.tech/docs/component/data/redis",

--- a/data/redis/v0/config/tasks.json
+++ b/data/redis/v0/config/tasks.json
@@ -70,7 +70,7 @@
       "type": "object"
     }
   },
-  "TASK_WRITE_chat-message": {
+  "TASK_WRITE_CHAT_MESSAGE": {
     "instillShortDescription": "Write chat message into Redis.",
     "input": {
       "instillUIOrder": 0,
@@ -153,7 +153,7 @@
       "type": "object"
     }
   },
-  "TASK_WRITE_MULTI_MODAL_chat-message": {
+  "TASK_WRITE_MULTI_MODAL_CHAT_MESSAGE": {
     "instillShortDescription": "Write multi-modal chat message into Redis.",
     "input": {
       "instillUIOrder": 0,


### PR DESCRIPTION
Because

- The task enum is wrong.

This commit

- Fixes the typo
