### PR TITLE
fix(openai): fix OpenAI image_url field can't work

### DIFF
--- a/ai/openai/v0/text_generation.go
+++ b/ai/openai/v0/text_generation.go
@@ -64,7 +64,7 @@ type imageURL struct {
 type content struct {
 	Type     string    `json:"type"`
 	Text     *string   `json:"text,omitempty"`
-	ImageURL *imageURL `json:"image-url,omitempty"`
+	ImageURL *imageURL `json:"image_url,omitempty"`
 }
 
 type textCompletionResp struct {


### PR DESCRIPTION
Because

- The `image_url` field in OpenAI component was not working due to a typo.

This commit

- Fixes the `image_url` field in OpenAI component.