### PR TITLE
feat(instill): remove extra-params field

### DIFF
--- a/ai/anthropic/v0/README.mdx
+++ b/ai/anthropic/v0/README.mdx
@@ -48,7 +48,6 @@ Provide text outputs in response to text inputs.
 | Model Name (required) | `model-name` | string | The Anthropic model to be used. |
 | Prompt (required) | `prompt` | string | The prompt text |
 | System message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model’s behavior is using a generic message as "You are a helpful assistant." |
-| Extra Parameters | `extra-params` | object | Extra Parameters |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: The prompt images will be injected in the order they are provided to the 'prompt' message. Anthropic doesn't support sending images via image-url, use this field instead) |
 | Chat history | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : \{"role": "The message role, i.e. 'system', 'user' or 'assistant'", "content": "message content"\}. |
 | Seed | `seed` | integer | The seed (Note: Not supported by Anthropic Models) |

--- a/ai/anthropic/v0/config/tasks.json
+++ b/ai/anthropic/v0/config/tasks.json
@@ -102,19 +102,6 @@
       ],
       "title": "Input",
       "type": "object"
-    },
-    "extra-params": {
-      "description": "Extra Parameters",
-      "instillAcceptFormats": [
-        "semi-structured/object"
-      ],
-      "instillUIOrder": 3,
-      "instillUpstreamTypes": [
-        "reference"
-      ],
-      "required": [],
-      "title": "Extra Parameters",
-      "type": "object"
     }
   },
   "TASK_TEXT_GENERATION_CHAT": {
@@ -143,9 +130,6 @@
           },
           "title": "Chat history",
           "type": "array"
-        },
-        "extra-params": {
-          "$ref": "#/$defs/extra-params"
         },
         "max-new-tokens": {
           "default": 50,

--- a/ai/instill/v0/README.mdx
+++ b/ai/instill/v0/README.mdx
@@ -182,7 +182,6 @@ Generate texts from input text prompts.
 | Model Name (required) | `model-name` | string | The Instill Model model to be used. |
 | Prompt (required) | `prompt` | string | The prompt text |
 | System message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model’s behavior is using a generic message as "You are a helpful assistant." |
-| Extra Parameters | `extra-params` | object | Extra Parameters |
 | Prompt Images | `prompt-images` | array[string] | The prompt images |
 | Chat history | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : \{"role": "The message role, i.e. 'system', 'user' or 'assistant'", "content": "message content"\}. |
 | Seed | `seed` | integer | The seed |
@@ -212,7 +211,6 @@ Generate texts from input text prompts and chat history.
 | Model Name (required) | `model-name` | string | The Instill Model model to be used. |
 | Prompt (required) | `prompt` | string | The prompt text |
 | System message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model’s behavior is using a generic message as "You are a helpful assistant." |
-| Extra Parameters | `extra-params` | object | Extra Parameters |
 | Prompt Images | `prompt-images` | array[string] | The prompt images |
 | Chat history | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : \{"role": "The message role, i.e. 'system', 'user' or 'assistant'", "content": "message content"\}. |
 | Seed | `seed` | integer | The seed |
@@ -241,7 +239,6 @@ Generate images from input text prompts.
 | Task ID (required) | `task` | string | `TASK_TEXT_TO_IMAGE` |
 | Model Name (required) | `model-name` | string | The Instill Model model to be used. |
 | Prompt (required) | `prompt` | string | The prompt text |
-| Extra Parameters | `extra-params` | object | Extra Parameters |
 | CFG Scale | `cfg-scale` | number | The guidance scale, default is 7.5 |
 | Samples | `samples` | integer | The number of generated samples, default is 1 |
 | Seed | `seed` | integer | The seed, default is 0 |
@@ -269,7 +266,6 @@ Answer questions based on a prompt and an image.
 | Model Name (required) | `model-name` | string | The Instill Model model to be used. |
 | Prompt (required) | `prompt` | string | The prompt text |
 | System message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model’s behavior is using a generic message as "You are a helpful assistant." |
-| Extra Parameters | `extra-params` | object | Extra Parameters |
 | Prompt Images (required) | `prompt-images` | array[string] | The prompt images |
 | Chat history | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : \{"role": "The message role, i.e. 'system', 'user' or 'assistant'", "content": "message content"\}. |
 | Seed | `seed` | integer | The seed |
@@ -298,7 +294,6 @@ Generate image from input text prompt and image.
 | Task ID (required) | `task` | string | `TASK_IMAGE_TO_IMAGE` |
 | Model Name (required) | `model-name` | string | The Instill Model model to be used. |
 | Prompt (required) | `prompt` | string | The prompt text |
-| Extra Parameters | `extra-params` | object | Extra Parameters |
 | Prompt Image (required) | `image-base64` | string | The prompt image |
 | CFG Scale | `cfg-scale` | number | The guidance scale, default is 7.5 |
 | Seed | `seed` | integer | The seed |

--- a/ai/instill/v0/config/tasks.json
+++ b/ai/instill/v0/config/tasks.json
@@ -64,19 +64,6 @@
       ],
       "title": "Input",
       "type": "object"
-    },
-    "extra-params": {
-      "description": "Extra Parameters",
-      "instillAcceptFormats": [
-        "semi-structured/object"
-      ],
-      "instillUIOrder": 3,
-      "instillUpstreamTypes": [
-        "reference"
-      ],
-      "required": [],
-      "title": "Extra Parameters",
-      "type": "object"
     }
   },
   "TASK_CLASSIFICATION": {
@@ -131,9 +118,6 @@
           ],
           "title": "CFG Scale",
           "type": "number"
-        },
-        "extra-params": {
-          "$ref": "#/$defs/extra-params"
         },
         "image-base64": {
           "description": "The prompt image",
@@ -334,9 +318,6 @@
           "title": "Chat history",
           "type": "array"
         },
-        "extra-params": {
-          "$ref": "#/$defs/extra-params"
-        },
         "max-new-tokens": {
           "default": 50,
           "description": "The maximum number of tokens for model to generate",
@@ -512,9 +493,6 @@
           "title": "CFG Scale",
           "type": "number"
         },
-        "extra-params": {
-          "$ref": "#/$defs/extra-params"
-        },
         "model-name": {
           "description": "The Instill Model model to be used.",
           "instillAcceptFormats": [
@@ -644,9 +622,6 @@
           },
           "title": "Chat history",
           "type": "array"
-        },
-        "extra-params": {
-          "$ref": "#/$defs/extra-params"
         },
         "max-new-tokens": {
           "default": 50,

--- a/ai/instill/v0/image_to_image.go
+++ b/ai/instill/v0/image_to_image.go
@@ -49,10 +49,6 @@ func (e *execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 			v := int32(input.GetFields()["seed"].GetNumberValue())
 			imageToImageInput.Seed = &v
 		}
-		if _, ok := input.GetFields()["extra-params"]; ok {
-			v := input.GetFields()["extra-params"].GetStructValue()
-			imageToImageInput.ExtraParams = v
-		}
 
 		taskInput := &modelPB.TaskInput_ImageToImage{
 			ImageToImage: imageToImageInput,

--- a/ai/instill/v0/llm_utils.go
+++ b/ai/instill/v0/llm_utils.go
@@ -122,10 +122,6 @@ func (e *execution) convertLLMInput(input *structpb.Struct) *LLMInput {
 		v := int32(input.GetFields()["seed"].GetNumberValue())
 		llmInput.Seed = &v
 	}
-	if _, ok := input.GetFields()["extra-params"]; ok {
-		v := input.GetFields()["extra-params"].GetStructValue()
-		llmInput.ExtraParams = v
-	}
 	return llmInput
 
 }


### PR DESCRIPTION
Because

- The `extra-params` field in the Instill Model component is confusing and difficult for users to understand. To improve usability, we have decided to remove it.

This commit

- Removes `extra-params` field.
