### PR TITLE
fix: typo

### DIFF
--- a/ai/anthropic/v0/config/definition.json
+++ b/ai/anthropic/v0/config/definition.json
@@ -3,7 +3,7 @@
     "TASK_TEXT_GENERATION_CHAT"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/latest/vdp/ai-connectors/anthropic",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/anthropic",
   "icon": "assets/anthropic.svg",
   "id": "anthropic",
   "public": true,


### PR DESCRIPTION
Because

- typo in anthropic definition

This commit

- fix typo
