### PR TITLE
feat: unify pipeline and component usage handlers

### DIFF
--- a/ai/anthropic/v0/component_test.go
+++ b/ai/anthropic/v0/component_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/base"
@@ -31,7 +30,7 @@ func TestComponent_Execute(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	testcases := []struct {
@@ -97,7 +96,7 @@ func TestComponent_Execute(t *testing.T) {
 func TestComponent_Connection(t *testing.T) {
 	c := qt.New(t)
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	c.Run("nok - error", func(c *qt.C) {
@@ -178,7 +177,7 @@ func (m *MockAnthropicClient) generateTextChat(request messagesReq) (messagesRes
 func TestComponent_Generation(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	mockHistory := []message{

--- a/ai/anthropic/v0/main.go
+++ b/ai/anthropic/v0/main.go
@@ -37,8 +37,7 @@ var (
 type component struct {
 	base.Component
 
-	usageHandlerCreator base.UsageHandlerCreator
-	secretAPIKey        string
+	secretAPIKey string
 }
 
 type AnthropicClient interface {
@@ -156,20 +155,6 @@ func (c *component) WithSecrets(s map[string]any) *component {
 	return c
 }
 
-// WithUsageHandlerCreator overrides the UsageHandlerCreator method.
-func (c *component) WithUsageHandlerCreator(newUH base.UsageHandlerCreator) *component {
-	c.usageHandlerCreator = newUH
-	return c
-}
-
-// UsageHandlerCreator returns a function to initialize a UsageHandler.
-func (c *component) UsageHandlerCreator() base.UsageHandlerCreator {
-	if c.usageHandlerCreator == nil {
-		return c.Component.UsageHandlerCreator()
-	}
-	return c.usageHandlerCreator
-}
-
 func (c *component) CreateExecution(sysVars map[string]any, setup *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 
 	resolvedSetup, resolved, err := c.resolveSecrets(setup)
@@ -248,7 +233,6 @@ func (e *execution) generateText(in *structpb.Struct) (*structpb.Struct, error) 
 		messages = append(messages, message)
 	}
 
-
 	finalMessage := message{
 		Role:    "user",
 		Content: []content{{Type: "text", Text: prompt}},
@@ -267,7 +251,6 @@ func (e *execution) generateText(in *structpb.Struct) (*structpb.Struct, error) 
 		}
 		finalMessage.Content = append(finalMessage.Content, image)
 	}
-
 
 	messages = append(messages, finalMessage)
 

--- a/ai/archetypeai/v0/component_test.go
+++ b/ai/archetypeai/v0/component_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/instill-ai/component/internal/util/httpclient"
 	"github.com/instill-ai/x/errmsg"
 
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -228,7 +227,7 @@ func TestComponent_Execute(t *testing.T) {
 		},
 	}
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	component := Init(bc)
 
 	for _, tc := range testcases {
@@ -288,7 +287,7 @@ func TestComponent_Execute(t *testing.T) {
 func TestComponent_CreateExecution(t *testing.T) {
 	c := qt.New(t)
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	component := Init(bc)
 
 	c.Run("nok - unsupported task", func(c *qt.C) {
@@ -304,7 +303,7 @@ func TestComponent_CreateExecution(t *testing.T) {
 func TestComponent_Test(t *testing.T) {
 	c := qt.New(t)
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	component := Init(bc)
 
 	c.Run("ok - connected", func(c *qt.C) {

--- a/ai/archetypeai/v0/main.go
+++ b/ai/archetypeai/v0/main.go
@@ -63,7 +63,7 @@ func Init(bc base.Component) *component {
 func (c *component) CreateExecution(sysVars map[string]any, setup *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
 	e := &execution{
 		ComponentExecution: base.ComponentExecution{Component: c, SystemVariables: sysVars, Setup: setup, Task: task},
-		client:             newClient(setup, c.Logger),
+		client:             newClient(setup, c.GetLogger()),
 	}
 
 	switch task {

--- a/ai/huggingface/v0/component_test.go
+++ b/ai/huggingface/v0/component_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/base"
@@ -221,7 +220,7 @@ func TestComponent_ExecuteSpeechRecognition(t *testing.T) {
 }
 
 func testTask(c *qt.C, p taskParams) {
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 	ctx := context.Background()
 

--- a/ai/huggingface/v0/main.go
+++ b/ai/huggingface/v0/main.go
@@ -568,7 +568,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 }
 
 func (c *component) Test(sysVars map[string]any, setup *structpb.Struct) error {
-	req := newClient(setup, c.Logger).R()
+	req := newClient(setup, c.GetLogger()).R()
 	resp, err := req.Get("")
 	if err != nil {
 		return err

--- a/ai/openai/v0/component_test.go
+++ b/ai/openai/v0/component_test.go
@@ -222,14 +222,14 @@ func TestComponent_WithConfig(t *testing.T) {
 
 		exec, err := connector.CreateExecution(nil, setup, task)
 		c.Assert(err, qt.IsNil)
-		c.Check(exec.Execution.UsesSecret(), qt.IsFalse)
+		c.Check(exec.Execution.UsesInstillCredentials(), qt.IsFalse)
 	})
 
 	c.Run("ok - with secret", func(c *qt.C) {
 		c.Cleanup(cleanupConn)
 
 		secrets := map[string]any{"apikey": apiKey}
-		connector := Init(bc).WithSecrets(secrets)
+		connector := Init(bc).WithInstillCredentials(secrets)
 
 		setup, err := structpb.NewStruct(map[string]any{
 			"base-path": "foo/bar",
@@ -239,7 +239,7 @@ func TestComponent_WithConfig(t *testing.T) {
 
 		exec, err := connector.CreateExecution(nil, setup, task)
 		c.Assert(err, qt.IsNil)
-		c.Check(exec.Execution.UsesSecret(), qt.IsTrue)
+		c.Check(exec.Execution.UsesInstillCredentials(), qt.IsTrue)
 	})
 
 	c.Run("nok - secret not injected", func(c *qt.C) {
@@ -253,7 +253,7 @@ func TestComponent_WithConfig(t *testing.T) {
 
 		_, err = connector.CreateExecution(nil, setup, task)
 		c.Check(err, qt.IsNotNil)
-		c.Check(err, qt.ErrorMatches, "unresolved global secret")
-		c.Check(errmsg.Message(err), qt.Equals, "The configuration field api-key can't reference a global secret.")
+		c.Check(err, qt.ErrorMatches, "unresolved global credential")
+		c.Check(errmsg.Message(err), qt.Matches, "The configuration field api-key references a global secret but.*")
 	})
 }

--- a/ai/openai/v0/main.go
+++ b/ai/openai/v0/main.go
@@ -48,8 +48,7 @@ var (
 type component struct {
 	base.Component
 
-	usageHandlerCreator base.UsageHandlerCreator
-	secretAPIKey        string
+	secretAPIKey string
 }
 
 // Init returns an initialized OpenAI connector.
@@ -71,20 +70,6 @@ func (c *component) WithSecrets(s map[string]any) *component {
 	c.secretAPIKey = base.ReadFromSecrets(cfgAPIKey, s)
 
 	return c
-}
-
-// WithUsageHandlerCreator overrides the UsageHandlerCreator method.
-func (c *component) WithUsageHandlerCreator(newUH base.UsageHandlerCreator) *component {
-	c.usageHandlerCreator = newUH
-	return c
-}
-
-// UsageHandlerCreator returns a function to initialize a UsageHandler.
-func (c *component) UsageHandlerCreator() base.UsageHandlerCreator {
-	if c.usageHandlerCreator == nil {
-		return c.Component.UsageHandlerCreator()
-	}
-	return c.usageHandlerCreator
 }
 
 // CreateExecution initializes a connector executor that can be used in a
@@ -371,7 +356,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 // Test checks the connector state.
 func (c *component) Test(_ map[string]any, setup *structpb.Struct) error {
 	models := ListModelsResponse{}
-	req := newClient(setup, c.Logger).R().SetResult(&models)
+	req := newClient(setup, c.GetLogger()).R().SetResult(&models)
 
 	if _, err := req.Get(listModelsPath); err != nil {
 		return err

--- a/ai/stabilityai/v0/component_test.go
+++ b/ai/stabilityai/v0/component_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/base"
@@ -47,7 +46,7 @@ func TestComponent_ExecuteImageFromText(t *testing.T) {
 	text := "a cat and a dog"
 	engine := "engine"
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	testcases := []struct {
@@ -142,7 +141,7 @@ func TestComponent_ExecuteImageFromImage(t *testing.T) {
 	text := "a cat and a dog"
 	engine := "engine"
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	testcases := []struct {
@@ -232,7 +231,7 @@ func TestComponent_ExecuteImageFromImage(t *testing.T) {
 func TestComponent_Test(t *testing.T) {
 	c := qt.New(t)
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	c.Run("nok - error", func(c *qt.C) {

--- a/ai/stabilityai/v0/main.go
+++ b/ai/stabilityai/v0/main.go
@@ -39,8 +39,7 @@ var (
 type component struct {
 	base.Component
 
-	usageHandlerCreator base.UsageHandlerCreator
-	secretAPIKey        string
+	secretAPIKey string
 }
 
 // Init returns an initialized StabilityAI connector.
@@ -62,20 +61,6 @@ func (c *component) WithSecrets(s map[string]any) *component {
 	c.secretAPIKey = base.ReadFromSecrets(cfgAPIKey, s)
 
 	return c
-}
-
-// WithUsageHandlerCreator overrides the UsageHandlerCreator method.
-func (c *component) WithUsageHandlerCreator(newUH base.UsageHandlerCreator) *component {
-	c.usageHandlerCreator = newUH
-	return c
-}
-
-// UsageHandlerCreator returns a function to initialize a UsageHandler.
-func (c *component) UsageHandlerCreator() base.UsageHandlerCreator {
-	if c.usageHandlerCreator == nil {
-		return c.Component.UsageHandlerCreator()
-	}
-	return c.usageHandlerCreator
 }
 
 // resolveSecrets looks for references to a global secret in the setup
@@ -185,7 +170,7 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 // Test checks the connector state.
 func (c *component) Test(sysVars map[string]any, setup *structpb.Struct) error {
 	var engines []Engine
-	req := newClient(setup, c.Logger).R().SetResult(&engines)
+	req := newClient(setup, c.GetLogger()).R().SetResult(&engines)
 
 	if _, err := req.Get(listEnginesPath); err != nil {
 		return err

--- a/ai/stabilityai/v0/main.go
+++ b/ai/stabilityai/v0/main.go
@@ -39,7 +39,7 @@ var (
 type component struct {
 	base.Component
 
-	secretAPIKey string
+	instillAPIKey string
 }
 
 // Init returns an initialized StabilityAI connector.
@@ -55,34 +55,35 @@ func Init(bc base.Component) *component {
 	return comp
 }
 
-// WithSecrets loads secrets into the connector, which can be used to configure
-// it with globaly defined parameters.
-func (c *component) WithSecrets(s map[string]any) *component {
-	c.secretAPIKey = base.ReadFromSecrets(cfgAPIKey, s)
-
+// WithInstillCredentials loads Instill credentials into the component, which
+// can be used to configure it with globally defined parameters instead of with
+// user-defined credential values.
+func (c *component) WithInstillCredentials(s map[string]any) *component {
+	c.instillAPIKey = base.ReadFromGlobalConfig(cfgAPIKey, s)
 	return c
 }
 
-// resolveSecrets looks for references to a global secret in the setup
-// and replaces them by the global secret injected during initialization.
-func (c *component) resolveSecrets(conn *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := conn.GetFields()[cfgAPIKey].GetStringValue()
+// resolveSetup checks whether the component is configured to use the Instill
+// credentials injected during initialization and, if so, returns a new setup
+// with the secret credential values.
+func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
+	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
 	if apiKey != base.SecretKeyword {
-		return conn, false, nil
+		return setup, false, nil
 	}
 
-	if c.secretAPIKey == "" {
-		return nil, false, base.NewUnresolvedSecret(cfgAPIKey)
+	if c.instillAPIKey == "" {
+		return nil, false, base.NewUnresolvedCredential(cfgAPIKey)
 	}
 
-	conn.GetFields()[cfgAPIKey] = structpb.NewStringValue(c.secretAPIKey)
-	return conn, true, nil
+	setup.GetFields()[cfgAPIKey] = structpb.NewStringValue(c.instillAPIKey)
+	return setup, true, nil
 }
 
 // CreateExecution initializes a connector executor that can be used in a
 // pipeline trigger.
 func (c *component) CreateExecution(sysVars map[string]any, setup *structpb.Struct, task string) (*base.ExecutionWrapper, error) {
-	resolvedSetup, resolved, err := c.resolveSecrets(setup)
+	resolvedSetup, resolved, err := c.resolveSetup(setup)
 	if err != nil {
 		return nil, err
 	}
@@ -94,17 +95,17 @@ func (c *component) CreateExecution(sysVars map[string]any, setup *structpb.Stru
 			Setup:           resolvedSetup,
 			Task:            task,
 		},
-		usesSecret: resolved,
+		usesInstillCredentials: resolved,
 	}}, nil
 }
 
 type execution struct {
 	base.ComponentExecution
-	usesSecret bool
+	usesInstillCredentials bool
 }
 
-func (e *execution) UsesSecret() bool {
-	return e.usesSecret
+func (e *execution) UsesInstillCredentials() bool {
+	return e.usesInstillCredentials
 }
 
 func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {

--- a/application/restapi/v0/component_test.go
+++ b/application/restapi/v0/component_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/base"
@@ -31,7 +30,7 @@ func TestComponent_Execute(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 	reqBody := map[string]any{
 		"title": "Be the wheel",
@@ -157,7 +156,7 @@ func TestComponent_Execute(t *testing.T) {
 func TestComponent_Test(t *testing.T) {
 	c := qt.New(t)
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	c.Run("ok - connected (even with non-2xx status", func(c *qt.C) {

--- a/application/slack/v0/component_test.go
+++ b/application/slack/v0/component_test.go
@@ -9,7 +9,6 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/instill-ai/component/base"
 	"github.com/slack-go/slack"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -103,7 +102,7 @@ const (
 func TestComponent_ExecuteWriteTask(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	testcases := []struct {
@@ -170,7 +169,7 @@ func TestComponent_ExecuteReadTask(t *testing.T) {
 
 	c := qt.New(t)
 	ctx := context.Background()
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	mockDateTime, _ := transformTSToDate("1715159449.399879", time.RFC3339)

--- a/base/component.go
+++ b/base/component.go
@@ -816,19 +816,14 @@ type ComponentExecution struct {
 	Task            string
 }
 
-func (e *ComponentExecution) GetTask() string {
-	return e.Task
-}
+// GetComponent returns the component interface that is triggering the execution.
+func (e *ComponentExecution) GetComponent() IComponent { return e.Component }
 
-func (e *ComponentExecution) GetSetup() *structpb.Struct {
-	return e.Setup
-}
-func (e *ComponentExecution) GetSystemVariables() map[string]any {
-	return e.SystemVariables
-}
-func (e *ComponentExecution) GetLogger() *zap.Logger {
-	return e.Component.GetLogger()
-}
+func (e *ComponentExecution) GetTask() string                    { return e.Task }
+func (e *ComponentExecution) GetSetup() *structpb.Struct         { return e.Setup }
+func (e *ComponentExecution) GetSystemVariables() map[string]any { return e.SystemVariables }
+func (e *ComponentExecution) GetLogger() *zap.Logger             { return e.Component.GetLogger() }
+
 func (e *ComponentExecution) GetTaskInputSchema() string {
 	return e.Component.GetTaskInputSchemas()[e.Task]
 }
@@ -839,9 +834,7 @@ func (e *ComponentExecution) GetTaskOutputSchema() string {
 // UsesSecret indicates wether the connector execution is configured with
 // global secrets. Components should override this method when they have the
 // ability to be executed with global secrets.
-func (e *ComponentExecution) UsesSecret() bool {
-	return false
-}
+func (e *ComponentExecution) UsesSecret() bool { return false }
 
 // UsageHandlerCreator returns a function to initialize a UsageHandler.
 func (e *ComponentExecution) UsageHandlerCreator() UsageHandlerCreator {

--- a/base/component.go
+++ b/base/component.go
@@ -65,8 +65,8 @@ func init() {
 // IComponent is the interface that wraps the basic component methods.
 // All component need to implement this interface.
 type IComponent interface {
-	GetID() string
-	GetUID() uuid.UUID
+	GetDefinitionID() string
+	GetDefinitionUID() uuid.UUID
 	GetLogger() *zap.Logger
 	GetTaskInputSchemas() map[string]string
 	GetTaskOutputSchemas() map[string]string
@@ -577,11 +577,13 @@ func checkFreeForm(compSpec *structpb.Struct) bool {
 	return false
 }
 
-func (c *Component) GetID() string {
+// GetDefinitionID returns the component definition ID.
+func (c *Component) GetDefinitionID() string {
 	return c.definition.Id
 }
 
-func (c *Component) GetUID() uuid.UUID {
+// GetDefinitionUID returns the component definition UID.
+func (c *Component) GetDefinitionUID() uuid.UUID {
 	return uuid.FromStringOrNil(c.definition.Uid)
 }
 

--- a/base/component.go
+++ b/base/component.go
@@ -844,19 +844,21 @@ func (e *ComponentExecution) GetTaskOutputSchema() string {
 	return e.Component.GetTaskOutputSchemas()[e.Task]
 }
 
-// UsesSecret indicates wether the connector execution is configured with
-// global secrets. Components should override this method when they have the
-// ability to be executed with global secrets.
-func (e *ComponentExecution) UsesSecret() bool { return false }
+// UsesInstillCredentials indicates wether the component setup includes the use
+// of global secrets (as opposed to a bring-your-own-key configuration) to
+// connect to external services. Components should override this method when
+// they have the ability to read global secrets and be executed without
+// explicit credentials.
+func (e *ComponentExecution) UsesInstillCredentials() bool { return false }
 
-// ReadFromSecrets reads a component secret from a secret map that comes from
-// environment variable configuration.
+// ReadFromGlobalConfig looks up a component credential field from a secret map
+// that comes from the environment variable configuration.
 //
 // Config parameters are defined with snake_case, but the
 // environment variable configuration loader replaces underscores by dots,
 // so we can't use the parameter key directly.
 // TODO using camelCase in configuration fields would fix this issue.
-func ReadFromSecrets(key string, secrets map[string]any) string {
+func ReadFromGlobalConfig(key string, secrets map[string]any) string {
 	sanitized := strings.ReplaceAll(key, "-", "")
 	if v, ok := secrets[sanitized].(string); ok {
 		return v

--- a/base/component_test.go
+++ b/base/component_test.go
@@ -1,13 +1,14 @@
 package base
 
 import (
-	_ "embed"
 	"encoding/json"
 	"testing"
 
-	qt "github.com/frankban/quicktest"
-	"go.uber.org/zap"
+	_ "embed"
+
 	"google.golang.org/protobuf/encoding/protojson"
+
+	qt "github.com/frankban/quicktest"
 )
 
 var (
@@ -25,12 +26,8 @@ var (
 
 func TestComponent_ListConnectorDefinitions(t *testing.T) {
 	c := qt.New(t)
-	logger := zap.NewNop()
 
-	conn := Component{
-		Logger: logger,
-	}
-
+	conn := new(Component)
 	err := conn.LoadDefinition(
 		connectorDefJSON,
 		connectorConfigJSON,

--- a/base/execution.go
+++ b/base/execution.go
@@ -30,7 +30,7 @@ type IExecution interface {
 
 	GetComponent() IComponent
 
-	UsesSecret() bool
+	UsesInstillCredentials() bool
 
 	Execute(context.Context, []*structpb.Struct) ([]*structpb.Struct, error)
 }
@@ -155,12 +155,13 @@ func (e *ExecutionWrapper) Execute(ctx context.Context, inputs []*structpb.Struc
 // initialization.
 const SecretKeyword = "__INSTILL_SECRET"
 
-// NewUnresolvedSecret returns an end-user error signaling that the component
-// configuration references a global secret that wasn't injected into the
-// component.
-func NewUnresolvedSecret(key string) error {
+// NewUnresolvedCredential returns an end-user error signaling that the
+// component setup contains credentials that reference a global secret that
+// wasn't injected into the component.
+func NewUnresolvedCredential(key string) error {
 	return errmsg.AddMessage(
-		fmt.Errorf("unresolved global secret"),
-		fmt.Sprintf("The configuration field %s can't reference a global secret.", key),
+		fmt.Errorf("unresolved global credential"),
+		fmt.Sprintf("The configuration field %s references a global secret "+
+			"but it doesn't support Instill Credentials.", key),
 	)
 }

--- a/base/execution.go
+++ b/base/execution.go
@@ -28,6 +28,8 @@ type IExecution interface {
 	GetTaskOutputSchema() string
 	GetSystemVariables() map[string]any
 
+	GetComponent() IComponent
+
 	UsesSecret() bool
 	UsageHandlerCreator() UsageHandlerCreator
 

--- a/base/execution.go
+++ b/base/execution.go
@@ -31,7 +31,6 @@ type IExecution interface {
 	GetComponent() IComponent
 
 	UsesSecret() bool
-	UsageHandlerCreator() UsageHandlerCreator
 
 	Execute(context.Context, []*structpb.Struct) ([]*structpb.Struct, error)
 }
@@ -124,7 +123,7 @@ func (e *ExecutionWrapper) Execute(ctx context.Context, inputs []*structpb.Struc
 		return nil, err
 	}
 
-	newUH := e.Execution.UsageHandlerCreator()
+	newUH := e.Execution.GetComponent().UsageHandlerCreator()
 	h, err := newUH(e.Execution)
 	if err != nil {
 		return nil, err

--- a/base/execution_test.go
+++ b/base/execution_test.go
@@ -1,0 +1,43 @@
+package base
+
+import (
+	"context"
+	"testing"
+
+	_ "embed"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestComponentExecution_GetComponent(t *testing.T) {
+	c := qt.New(t)
+	logger := zap.NewNop()
+
+	cmp := &testComp{Component{Logger: logger}}
+	err := cmp.LoadDefinition(
+		connectorDefJSON,
+		connectorConfigJSON,
+		connectorTasksJSON,
+		map[string][]byte{"additional.json": connectorAdditionalJSON})
+	c.Assert(err, qt.IsNil)
+
+	x, _ := cmp.CreateExecution(nil, nil, "TASK_TEXT_EMBEDDINGS")
+	got := x.Execution.GetComponent()
+	c.Check(got.GetID(), qt.Equals, "openai")
+}
+
+type testExec struct{ ComponentExecution }
+
+func (e *testExec) Execute(_ context.Context, _ []*structpb.Struct) ([]*structpb.Struct, error) {
+	return nil, nil
+}
+
+type testComp struct{ Component }
+
+func (c *testComp) CreateExecution(_ map[string]any, _ *structpb.Struct, task string) (*ExecutionWrapper, error) {
+	x := ComponentExecution{Component: c, Task: task}
+	return &ExecutionWrapper{Execution: &testExec{x}}, nil
+}

--- a/base/execution_test.go
+++ b/base/execution_test.go
@@ -6,7 +6,6 @@ import (
 
 	_ "embed"
 
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	qt "github.com/frankban/quicktest"
@@ -14,9 +13,8 @@ import (
 
 func TestComponentExecution_GetComponent(t *testing.T) {
 	c := qt.New(t)
-	logger := zap.NewNop()
 
-	cmp := &testComp{Component{Logger: logger}}
+	cmp := &testComp{Component{}}
 	err := cmp.LoadDefinition(
 		connectorDefJSON,
 		connectorConfigJSON,

--- a/base/execution_test.go
+++ b/base/execution_test.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	_ "embed"
@@ -14,7 +15,11 @@ import (
 func TestComponentExecution_GetComponent(t *testing.T) {
 	c := qt.New(t)
 
-	cmp := &testComp{Component{}}
+	cmp := &testComp{
+		Component: Component{
+			NewUsageHandler: usageHandlerCreator(nil, nil),
+		},
+	}
 	err := cmp.LoadDefinition(
 		connectorDefJSON,
 		connectorConfigJSON,
@@ -22,20 +27,330 @@ func TestComponentExecution_GetComponent(t *testing.T) {
 		map[string][]byte{"additional.json": connectorAdditionalJSON})
 	c.Assert(err, qt.IsNil)
 
-	x, _ := cmp.CreateExecution(nil, nil, "TASK_TEXT_EMBEDDINGS")
+	x, err := cmp.CreateExecution(nil, nil, "TASK_TEXT_EMBEDDINGS")
+	c.Assert(err, qt.IsNil)
+
 	got := x.Execution.GetComponent()
 	c.Check(got.GetDefinitionID(), qt.Equals, "openai")
 }
 
-type testExec struct{ ComponentExecution }
+func TestExecutionWrapper_Execute(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
 
-func (e *testExec) Execute(_ context.Context, _ []*structpb.Struct) ([]*structpb.Struct, error) {
-	return nil, nil
+	inputValid := map[string]any{
+		"text":  "What's Horace Andy's biggest hit?",
+		"model": "text-embedding-ada-002",
+	}
+	outputValid := map[string]any{"embedding": []any{0.001}}
+
+	testcases := []struct {
+		name       string
+		in         map[string]any
+		checkErr   error
+		collectErr error
+		out        map[string]any
+		outErr     error
+		want       map[string]any
+		wantErr    string
+	}{
+		{
+			name:    "nok - invalid input",
+			in:      map[string]any{"text": "What's Horace Andy's biggest hit?"},
+			wantErr: `inputs\[0\]: missing properties: 'model'`,
+		},
+		{
+			name:     "nok - check error",
+			in:       inputValid,
+			checkErr: fmt.Errorf("foo"),
+			wantErr:  "foo",
+		},
+		{
+			name:    "nok - invalid output",
+			in:      inputValid,
+			out:     map[string]any{"response": "Sky Larking, definitely!"},
+			wantErr: `outputs\[0\]: missing properties: 'embedding'`,
+		},
+		{
+			name:    "nok - execution error",
+			in:      inputValid,
+			outErr:  fmt.Errorf("bar"),
+			wantErr: "bar",
+		},
+		{
+			name:       "nok - collect error",
+			in:         inputValid,
+			out:        outputValid,
+			collectErr: fmt.Errorf("zot"),
+			wantErr:    "zot",
+		},
+		{
+			name: "ok",
+			in:   inputValid,
+			out:  outputValid,
+			want: outputValid,
+		},
+	}
+
+	for _, tc := range testcases {
+		c.Run(tc.name, func(c *qt.C) {
+			cmp := &testComp{
+				Component: Component{
+					NewUsageHandler: usageHandlerCreator(tc.checkErr, tc.collectErr),
+				},
+				xOut: []map[string]any{tc.out},
+				xErr: tc.outErr,
+			}
+
+			err := cmp.LoadDefinition(
+				connectorDefJSON,
+				connectorConfigJSON,
+				connectorTasksJSON,
+				map[string][]byte{"additional.json": connectorAdditionalJSON})
+			c.Assert(err, qt.IsNil)
+
+			x, err := cmp.CreateExecution(nil, nil, "TASK_TEXT_EMBEDDINGS")
+			c.Assert(err, qt.IsNil)
+
+			pbin, err := structpb.NewStruct(tc.in)
+			c.Assert(err, qt.IsNil)
+
+			got, err := x.Execute(ctx, []*structpb.Struct{pbin})
+			if tc.wantErr != "" {
+				c.Check(err, qt.IsNotNil)
+				c.Check(err, qt.ErrorMatches, tc.wantErr)
+				return
+			}
+
+			c.Check(err, qt.IsNil)
+			c.Assert(got, qt.HasLen, 1)
+
+			gotJSON, err := got[0].MarshalJSON()
+			c.Assert(err, qt.IsNil)
+			c.Check(gotJSON, qt.JSONEquals, tc.want)
+		})
+	}
 }
 
-type testComp struct{ Component }
+/*
+// TODO check usage handler - check error
+// TODO check usage handler - collect error
+// TODO check usage handler - no error
+func TestExecutionWrapper_Execute(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	cmp := &testComp{Component{
+		// NewUsageHandler: creator.newUH,
+	}}
+	err := cmp.LoadDefinition(
+		connectorDefJSON,
+		connectorConfigJSON,
+		connectorTasksJSON,
+		map[string][]byte{"additional.json": connectorAdditionalJSON})
+		c.Assert(err, qt.IsNil)
+
+	want := TextCompletionOutput{
+		Texts: []string{"hello!"},
+		Usage: usage{TotalTokens: 25},
+	}
+	resp := `{"usage": {"total_tokens": 25}, "choices": [{"message": {"content": "hello!"}}]}`
+
+	pbIn, err := base.ConvertToStructpb(TextCompletionInput{
+		Model:  "gpt-3.5-turbo",
+		Prompt: "what instrument did Yusef Lateef play?",
+		Images: []string{},
+	})
+	c.Assert(err, qt.IsNil)
+	inputs := []*structpb.Struct{pbIn}
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Authorization"), qt.Equals, "Bearer "+apiKey)
+
+		w.Header().Set("Content-Type", httpclient.MIMETypeJSON)
+		fmt.Fprintln(w, resp)
+	})
+
+	task := TextGenerationTask
+	bc := new(base.Component)
+
+	/*
+	c.Run("nok - usage handler check error", func(c *qt.C) {
+		c.Cleanup(cleanupConn)
+
+		uh := mock.NewUsageHandlerMock(c)
+		uh.CheckMock.When(minimock.AnyContext, inputs).Then(fmt.Errorf("check error"))
+		creator := usageHandlerCreator{uh}
+
+		bc := base.Component{NewUsageHandler: creator.newUH}
+		connector := Init(bc)
+
+		setup, err := structpb.NewStruct(map[string]any{})
+		c.Assert(err, qt.IsNil)
+
+		exec, err := connector.CreateExecution(nil, setup, task)
+		c.Assert(err, qt.IsNil)
+
+		_, err = exec.Execute(ctx, inputs)
+		c.Check(err, qt.IsNotNil)
+		c.Check(err, qt.ErrorMatches, "check error")
+	})
+
+	c.Run("nok - usage handler collect error", func(c *qt.C) {
+		c.Cleanup(cleanupConn)
+
+		uh := mock.NewUsageHandlerMock(c)
+		uh.CheckMock.When(minimock.AnyContext, inputs).Then(nil)
+		uh.CollectMock.When(minimock.AnyContext, inputs, outputs).Then(fmt.Errorf("collect error"))
+		creator := usageHandlerCreator{uh}
+
+		bc := base.Component{NewUsageHandler: creator.newUH}
+		connector := Init(bc)
+
+		setup, err := structpb.NewStruct(map[string]any{
+			"base-path": openAIServer.URL,
+			"api-key":   apiKey,
+		})
+		c.Assert(err, qt.IsNil)
+
+		exec, err := connector.CreateExecution(nil, setup, task)
+		c.Assert(err, qt.IsNil)
+
+		_, err = exec.Execute(ctx, inputs)
+		c.Check(err, qt.IsNotNil)
+		c.Check(err, qt.ErrorMatches, "collect error")
+	})
+
+	c.Run("ok - with usage handler", func(c *qt.C) {
+		c.Cleanup(cleanupConn)
+
+		uh := mock.NewUsageHandlerMock(c)
+		uh.CheckMock.Return(nil)   //.When(minimock.AnyContext, minimock.Any).Then(nil)
+		uh.CollectMock.Return(nil) //.When(minimock.AnyContext, inputs, minimock.Any).Then(nil)
+		creator := usageHandlerCreator{uh}
+
+		bc.NewUsageHandler = creator.newUH
+
+		c.Cleanup(func() { bc.NewUsageHandler = nil })
+
+		connector := Init(bc)
+
+		setup, err := structpb.NewStruct(map[string]any{
+			"base-path": openAIServer.URL,
+			"api-key":   apiKey,
+		})
+		c.Assert(err, qt.IsNil)
+
+		exec, err := connector.CreateExecution(nil, setup, task)
+		c.Assert(err, qt.IsNil)
+		c.Check(exec.Execution.UsesSecret(), qt.IsFalse)
+
+		got, err := exec.Execute(ctx, inputs)
+		c.Check(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+
+		gotJSON, err := got[0].MarshalJSON()
+		c.Assert(err, qt.IsNil)
+		c.Check(gotJSON, qt.JSONEquals, want)
+	})
+
+
+	c.Run("ok - with secrets & usage handler", func(c *qt.C) {
+		c.Cleanup(cleanupConn)
+
+		secrets := map[string]any{"apikey": apiKey}
+		connector := Init(bc).WithSecrets(secrets)
+
+		setup, err := structpb.NewStruct(map[string]any{
+			"base-path": openAIServer.URL,
+			"api-key":   "__INSTILL_SECRET", // will be replaced by secrets.apikey
+		})
+		c.Assert(err, qt.IsNil)
+
+		exec, err := connector.CreateExecution(nil, setup, task)
+		c.Assert(err, qt.IsNil)
+		c.Check(exec.Execution.UsesSecret(), qt.IsTrue)
+
+		got, err := exec.Execute(ctx, inputs)
+		c.Check(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+
+		gotJSON, err := got[0].MarshalJSON()
+		c.Assert(err, qt.IsNil)
+		c.Check(gotJSON, qt.JSONEquals, want)
+	})
+
+	c.Run("nok - secret not injected", func(c *qt.C) {
+		c.Cleanup(cleanupConn)
+
+		connector := Init(bc)
+		setup, err := structpb.NewStruct(map[string]any{
+			"api-key": "__INSTILL_SECRET",
+		})
+		c.Assert(err, qt.IsNil)
+
+		_, err = connector.CreateExecution(nil, setup, task)
+		c.Check(err, qt.IsNotNil)
+		c.Check(err, qt.ErrorMatches, "unresolved global secret")
+		c.Check(errmsg.Message(err), qt.Equals, "The configuration field api-key can't reference a global secret.")
+	})
+}
+*/
+
+type testExec struct {
+	ComponentExecution
+
+	out []map[string]any
+	err error
+}
+
+func (e *testExec) Execute(_ context.Context, _ []*structpb.Struct) ([]*structpb.Struct, error) {
+	if e.out == nil {
+		return nil, e.err
+	}
+
+	pbout := make([]*structpb.Struct, len(e.out))
+	for i, o := range e.out {
+		pbo, err := structpb.NewStruct(o)
+		if err != nil {
+			panic(err)
+		}
+		pbout[i] = pbo
+	}
+
+	return pbout, e.err
+}
+
+type testComp struct {
+	Component
+
+	// execution output
+	xOut []map[string]any
+	xErr error
+}
 
 func (c *testComp) CreateExecution(_ map[string]any, _ *structpb.Struct, task string) (*ExecutionWrapper, error) {
 	x := ComponentExecution{Component: c, Task: task}
-	return &ExecutionWrapper{Execution: &testExec{x}}, nil
+	return &ExecutionWrapper{Execution: &testExec{
+		ComponentExecution: x,
+
+		out: c.xOut,
+		err: c.xErr,
+	}}, nil
 }
+
+func usageHandlerCreator(checkErr, collectErr error) UsageHandlerCreator {
+	return func(IExecution) (UsageHandler, error) {
+		return &usageHandler{
+			checkErr:   checkErr,
+			collectErr: collectErr,
+		}, nil
+	}
+}
+
+type usageHandler struct {
+	checkErr   error
+	collectErr error
+}
+
+func (h *usageHandler) Check(context.Context, []*structpb.Struct) error          { return h.checkErr }
+func (h *usageHandler) Collect(_ context.Context, _, _ []*structpb.Struct) error { return h.collectErr }

--- a/base/execution_test.go
+++ b/base/execution_test.go
@@ -24,7 +24,7 @@ func TestComponentExecution_GetComponent(t *testing.T) {
 
 	x, _ := cmp.CreateExecution(nil, nil, "TASK_TEXT_EMBEDDINGS")
 	got := x.Execution.GetComponent()
-	c.Check(got.GetID(), qt.Equals, "openai")
+	c.Check(got.GetDefinitionID(), qt.Equals, "openai")
 }
 
 type testExec struct{ ComponentExecution }

--- a/base/usage.go
+++ b/base/usage.go
@@ -18,10 +18,8 @@ type UsageHandlerCreator func(IExecution) (UsageHandler, error)
 
 type noopUsageHandler struct{}
 
-func (h *noopUsageHandler) Check(context.Context, []*structpb.Struct) error { return nil }
-func (h *noopUsageHandler) Collect(_ context.Context, _, _ []*structpb.Struct) error {
-	return nil
-}
+func (h *noopUsageHandler) Check(context.Context, []*structpb.Struct) error          { return nil }
+func (h *noopUsageHandler) Collect(_ context.Context, _, _ []*structpb.Struct) error { return nil }
 
 // NewNoopUsageHandler is a no-op usage handler initializer.
 func NewNoopUsageHandler(IExecution) (UsageHandler, error) {

--- a/data/pinecone/v0/component_test.go
+++ b/data/pinecone/v0/component_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/base"
@@ -192,7 +191,7 @@ func TestComponent_Execute(t *testing.T) {
 		},
 	}
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	connector := Init(bc)
 
 	for _, tc := range testcases {

--- a/operator/json/v0/component_test.go
+++ b/operator/json/v0/component_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/base"
@@ -116,7 +115,7 @@ func TestOperator_Execute(t *testing.T) {
 		},
 	}
 
-	bo := base.Component{Logger: zap.NewNop()}
+	bo := base.Component{}
 	operator := Init(bo)
 
 	for _, tc := range testcases {
@@ -153,7 +152,7 @@ func TestOperator_Execute(t *testing.T) {
 func TestOperator_CreateExecution(t *testing.T) {
 	c := qt.New(t)
 
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	operator := Init(bc)
 
 	c.Run("nok - unsupported task", func(c *qt.C) {

--- a/operator/text/v0/main_test.go
+++ b/operator/text/v0/main_test.go
@@ -10,7 +10,6 @@ import (
 	"code.sajari.com/docconv"
 	"github.com/frankban/quicktest"
 	"github.com/instill-ai/component/base"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -67,7 +66,7 @@ func TestOperator(t *testing.T) {
 			input: structpb.Struct{},
 		},
 	}
-	bc := base.Component{Logger: zap.NewNop()}
+	bc := base.Component{}
 	ctx := context.Background()
 	for i := range testcases {
 		tc := &testcases[i]

--- a/store/store.go
+++ b/store/store.go
@@ -86,7 +86,7 @@ func Init(
 			conn := stabilityai.Init(baseComp)
 
 			// Secret doesn't allow hyphens
-			conn = conn.WithSecrets(secrets["stabilityai"])
+			conn = conn.WithInstillCredentials(secrets["stabilityai"])
 			compStore.Import(conn)
 		}
 
@@ -96,13 +96,13 @@ func Init(
 		{
 			// OpenAI
 			conn := openai.Init(baseComp)
-			conn = conn.WithSecrets(secrets[conn.GetID()])
+			conn = conn.WithInstillCredentials(secrets[conn.GetID()])
 			compStore.Import(conn)
 		}
 		{
 			// Anthropic
 			conn := anthropic.Init(baseComp)
-			conn = conn.WithSecrets(secrets[conn.GetID()])
+			conn = conn.WithInstillCredentials(secrets[conn.GetID()])
 			compStore.Import(conn)
 		}
 

--- a/store/store.go
+++ b/store/store.go
@@ -63,9 +63,12 @@ type ComponentSecrets map[string]map[string]any
 func Init(
 	logger *zap.Logger,
 	secrets ComponentSecrets,
-	usageHandlerCreators map[string]base.UsageHandlerCreator,
+	usageHandlerCreator base.UsageHandlerCreator,
 ) *Store {
-	baseComp := base.Component{Logger: logger}
+	baseComp := base.Component{
+		Logger:          logger,
+		NewUsageHandler: usageHandlerCreator,
+	}
 
 	once.Do(func() {
 		compStore = &Store{
@@ -83,8 +86,7 @@ func Init(
 			conn := stabilityai.Init(baseComp)
 
 			// Secret doesn't allow hyphens
-			conn = conn.WithSecrets(secrets["stabilityai"]).
-				WithUsageHandlerCreator(usageHandlerCreators[conn.GetID()])
+			conn = conn.WithSecrets(secrets["stabilityai"])
 			compStore.Import(conn)
 		}
 
@@ -94,15 +96,13 @@ func Init(
 		{
 			// OpenAI
 			conn := openai.Init(baseComp)
-			conn = conn.WithSecrets(secrets[conn.GetID()]).
-				WithUsageHandlerCreator(usageHandlerCreators[conn.GetID()])
+			conn = conn.WithSecrets(secrets[conn.GetID()])
 			compStore.Import(conn)
 		}
 		{
 			// Anthropic
 			conn := anthropic.Init(baseComp)
-			conn = conn.WithSecrets(secrets[conn.GetID()]).
-				WithUsageHandlerCreator(usageHandlerCreators[conn.GetID()])
+			conn = conn.WithSecrets(secrets[conn.GetID()])
 			compStore.Import(conn)
 		}
 

--- a/store/store.go
+++ b/store/store.go
@@ -96,13 +96,13 @@ func Init(
 		{
 			// OpenAI
 			conn := openai.Init(baseComp)
-			conn = conn.WithInstillCredentials(secrets[conn.GetID()])
+			conn = conn.WithInstillCredentials(secrets[conn.GetDefinitionID()])
 			compStore.Import(conn)
 		}
 		{
 			// Anthropic
 			conn := anthropic.Init(baseComp)
-			conn = conn.WithInstillCredentials(secrets[conn.GetID()])
+			conn = conn.WithInstillCredentials(secrets[conn.GetDefinitionID()])
 			compStore.Import(conn)
 		}
 
@@ -125,9 +125,9 @@ func Init(
 // Import loads the component definitions into memory.
 func (s *Store) Import(comp base.IComponent) {
 	c := &component{comp: comp}
-	s.componentUIDMap[comp.GetUID()] = c
-	s.componentIDMap[comp.GetID()] = c
-	s.componentUIDs = append(s.componentUIDs, comp.GetUID())
+	s.componentUIDMap[comp.GetDefinitionUID()] = c
+	s.componentIDMap[comp.GetDefinitionID()] = c
+	s.componentUIDs = append(s.componentUIDs, comp.GetDefinitionUID())
 }
 
 // CreateExecution initializes the execution of a component given its UID.


### PR DESCRIPTION
Because

- We have usage handlers for pipeline and component but the former only receives the number of components. We can merge them and simplify our logic.
- When a component is configured to use (secret) credentials injected from the environment variables in the configuration (e.g. when a global OpenAI API key is set), the component logic always references these values as global secrets, and sometimes just "secrets". This is confusing because users can define their own secrets. "Instill Credentials" is more concrete and less confusing.
- The `GetID()` method in the `IComponent` interface actually refers to the component definition ID. At some point we'll actually want to know the component ID (i.e. the component in the pipeline `mycomponent-1` vs the definition `mycomponent`), e.g. for pipeline trigger logging.

This commit

- Simplifies the usage handler logic. Instead of receiving a map (component def ID->usage handler), a single handler is received, which is responsible of accessing the definition ID and apply the relevant logic.
- Names for global secrets and component definition IDs in the component and execution interfaces are updated. We don't implement the ID accessor (yet) but we set the proper name for the definition ID getter.
