### PR TITLE
feat(openai): add dimensions in openai component

### DIFF
--- a/ai/openai/v0/config/tasks.json
+++ b/ai/openai/v0/config/tasks.json
@@ -173,6 +173,19 @@
           ],
           "title": "Text",
           "type": "string"
+        },
+        "dimensions": {
+          "description": "The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Dimensions",
+          "type": "integer"
         }
       },
       "required": [

--- a/ai/openai/v0/main.go
+++ b/ai/openai/v0/main.go
@@ -230,8 +230,9 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 
 			resp := TextEmbeddingsResp{}
 			req := client.R().SetBody(TextEmbeddingsReq{
-				Model: inputStruct.Model,
-				Input: []string{inputStruct.Text},
+				Model:      inputStruct.Model,
+				Input:      []string{inputStruct.Text},
+				Dimensions: inputStruct.Dimensions,
 			}).SetResult(&resp)
 
 			if _, err := req.Post(embeddingsPath); err != nil {

--- a/ai/openai/v0/main.go
+++ b/ai/openai/v0/main.go
@@ -229,11 +229,22 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 			}
 
 			resp := TextEmbeddingsResp{}
-			req := client.R().SetBody(TextEmbeddingsReq{
-				Model:      inputStruct.Model,
-				Input:      []string{inputStruct.Text},
-				Dimensions: inputStruct.Dimensions,
-			}).SetResult(&resp)
+
+			var reqParams TextEmbeddingsReq
+			if inputStruct.Dimensions == 0 {
+				reqParams = TextEmbeddingsReq{
+					Model: inputStruct.Model,
+					Input: []string{inputStruct.Text},
+				}
+			} else {
+				reqParams = TextEmbeddingsReq{
+					Model:      inputStruct.Model,
+					Input:      []string{inputStruct.Text},
+					Dimensions: inputStruct.Dimensions,
+				}
+			}
+
+			req := client.R().SetBody(reqParams).SetResult(&resp)
 
 			if _, err := req.Post(embeddingsPath); err != nil {
 				return inputs, err

--- a/ai/openai/v0/text_embeddings.go
+++ b/ai/openai/v0/text_embeddings.go
@@ -16,7 +16,7 @@ type TextEmbeddingsOutput struct {
 
 type TextEmbeddingsReq struct {
 	Model      string   `json:"model"`
-	Dimensions int      `json:"dimensions"`
+	Dimensions int      `json:"dimensions,omitempty"`
 	Input      []string `json:"input"`
 }
 

--- a/ai/openai/v0/text_embeddings.go
+++ b/ai/openai/v0/text_embeddings.go
@@ -5,8 +5,9 @@ const (
 )
 
 type TextEmbeddingsInput struct {
-	Text  string `json:"text"`
-	Model string `json:"model"`
+	Text       string `json:"text"`
+	Model      string `json:"model"`
+	Dimensions int    `json:"dimensions"`
 }
 
 type TextEmbeddingsOutput struct {
@@ -14,8 +15,9 @@ type TextEmbeddingsOutput struct {
 }
 
 type TextEmbeddingsReq struct {
-	Model string   `json:"model"`
-	Input []string `json:"input"`
+	Model      string   `json:"model"`
+	Dimensions int      `json:"dimensions"`
+	Input      []string `json:"input"`
 }
 
 type TextEmbeddingsResp struct {


### PR DESCRIPTION
Because

- in many use cases, users may not need to output vectors of such high dimensionality and might only require the first 'x' dimensions.

This commit

- add dimensions in api caller
