### PR TITLE
feat: add JQ input field that accepts any type

### DIFF
--- a/operator/json/v0/README.mdx
+++ b/operator/json/v0/README.mdx
@@ -80,8 +80,9 @@ Process JSON through a `jq` command
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_JQ` |
-| JSON input (required) | `jsonInput` | string | JSON string to be processed |
+| JSON value | `json-value` | any | JSON value (e.g. string, number, object, array...) to be processed by the filter |
 | Filter (required) | `jqFilter` | string | Filter, in `jq` syntax, that will be applied to the JSON input |
+| (DEPRECATED) JSON input | `jsonInput` | string | (DEPRECATED, use 'JSON value' instead) JSON string to be processed. This field allows templated inputs, but the data might preprocessing (marshalling). This field will be used in absence of 'JSON value' for backwards compatibility reasons. |
 
 
 

--- a/operator/json/v0/config/tasks.json
+++ b/operator/json/v0/config/tasks.json
@@ -115,8 +115,9 @@
       "instillUIOrder": 0,
       "properties": {
         "jsonInput": {
-          "instillUIOrder": 0,
-          "description": "JSON string to be processed",
+          "instillUIOrder": 2,
+          "description": "(DEPRECATED, use 'JSON value' instead) JSON string to be processed. This field allows templated inputs, but the data might preprocessing (marshalling). This field will be used in absence of 'JSON value' for backwards compatibility reasons.",
+          "instillShortDescription": "(DEPRECATED) JSON string to be processed",
           "instillAcceptFormats": [
             "string"
           ],
@@ -126,8 +127,23 @@
             "template"
           ],
           "instillUIMultiline": true,
-          "title": "JSON input",
+          "title": "(DEPRECATED) JSON input",
           "type": "string"
+        },
+        "json-value": {
+          "instillUIOrder": 0,
+          "description": "JSON value (e.g. string, number, object, array...) to be processed by the filter",
+          "instillAcceptFormats": [
+            "object",
+            "structured/*",
+            "semi-structured/*"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "instillUIMultiline": true,
+          "title": "JSON value"
         },
         "jqFilter": {
           "instillUIOrder": 1,
@@ -146,7 +162,10 @@
         }
       },
       "required": [
-        "jsonInput",
+        "jqFilter"
+      ],
+      "instillEditOnNodeFields": [
+        "json-value",
         "jqFilter"
       ],
       "title": "Input",

--- a/operator/json/v0/main.go
+++ b/operator/json/v0/main.go
@@ -3,10 +3,11 @@ package json
 
 import (
 	"context"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"sync"
+
+	_ "embed"
 
 	"github.com/itchyny/gojq"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -94,14 +95,12 @@ func (e *execution) unmarshal(in *structpb.Struct) (*structpb.Struct, error) {
 	out := new(structpb.Struct)
 
 	b := []byte(in.Fields["string"].GetStringValue())
-	obj := new(structpb.Struct)
+	obj := new(structpb.Value)
 	if err := protojson.Unmarshal(b, obj); err != nil {
 		return nil, errmsg.AddMessage(err, "Couldn't parse the JSON string. Please check the syntax is correct.")
 	}
 
-	out.Fields = map[string]*structpb.Value{
-		"json": structpb.NewStructValue(obj),
-	}
+	out.Fields = map[string]*structpb.Value{"json": obj}
 
 	return out, nil
 }
@@ -109,10 +108,12 @@ func (e *execution) unmarshal(in *structpb.Struct) (*structpb.Struct, error) {
 func (e *execution) jq(in *structpb.Struct) (*structpb.Struct, error) {
 	out := new(structpb.Struct)
 
-	b := []byte(in.Fields["jsonInput"].GetStringValue())
-	var input any
-	if err := json.Unmarshal(b, &input); err != nil {
-		return nil, errmsg.AddMessage(err, "Couldn't parse the JSON input. Please check the syntax is correct.")
+	input := in.Fields["json-value"].AsInterface()
+	if input == nil {
+		b := []byte(in.Fields["jsonInput"].GetStringValue())
+		if err := json.Unmarshal(b, &input); err != nil {
+			return nil, errmsg.AddMessage(err, "Couldn't parse the JSON input. Please check the syntax is correct.")
+		}
 	}
 
 	queryStr := in.Fields["jqFilter"].GetStringValue()


### PR DESCRIPTION
Because

- The `jq` task took only strings, which can be leveraged for reference but forced users to pre-process objects with another JSON operator that marshalled the input.

This commit

- Introduces a new input field for the task, which can be any object
  - The old value is hidden under the "More" settings section. If the new field is empty, task will fall back to the old field (for backwards compatibility).
- Removes object type assumption in unmarshal task: now it can unmarshal any valid JSON value.
