### PR TITLE
feat(instill): send requester UID, if present, on model trigger

### DIFF
--- a/ai/instill/v0/main.go
+++ b/ai/instill/v0/main.go
@@ -68,6 +68,10 @@ func getInstillUserUID(vars map[string]any) string {
 	return vars["__PIPELINE_USER_UID"].(string)
 }
 
+func getInstillRequesterUID(vars map[string]any) string {
+	return vars["__PIPELINE_REQUESTER_UID"].(string)
+}
+
 func getModelServerURL(vars map[string]any) string {
 	if v, ok := vars["__MODEL_BACKEND"]; ok {
 		return v.(string)
@@ -83,11 +87,17 @@ func getMgmtServerURL(vars map[string]any) string {
 }
 
 func getRequestMetadata(vars map[string]any) metadata.MD {
-	return metadata.Pairs(
+	md := metadata.Pairs(
 		"Authorization", getHeaderAuthorization(vars),
 		"Instill-User-Uid", getInstillUserUID(vars),
 		"Instill-Auth-Type", "user",
 	)
+
+	if requester := getInstillRequesterUID(vars); requester != "" {
+		md.Set("Instill-Requester-Uid", requester)
+	}
+
+	return md
 }
 
 func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*structpb.Struct, error) {


### PR DESCRIPTION
Because

- Instill Model will [use the requester UID,](https://github.com/instill-ai/model-backend/pull/619/files) when present, in model execution.

This commit

- Adds the requester header to the trigger model call in the `instill` component.
