### PR TITLE
feat: add handler to auto-fill missing default values

### DIFF
--- a/application/github/v0/main.go
+++ b/application/github/v0/main.go
@@ -100,7 +100,7 @@ func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*
 	outputs := make([]*structpb.Struct, len(inputs))
 
 	for i, input := range inputs {
-		if err := e.FillInDefaultValues(input); err != nil {
+		if _, err := e.FillInDefaultValues(input); err != nil {
 			return nil, err
 		}
 		output, err := e.execute(ctx, input)

--- a/base/component.go
+++ b/base/component.go
@@ -987,6 +987,8 @@ func (e *ComponentExecution) fillInDefaultValuesWithReference(input *structpb.St
 					}
 					tempArray.Values = append(tempArray.Values, val)
 				}
+			default:
+				continue
 			}
 			input.GetFields()[key] = structpb.NewListValue(tempArray)
 		}


### PR DESCRIPTION
Because:
 - Request from frontend and direct API calls may miss some optional fields
 - The underlying meaning of default is that if no value is provided, we will use this value instead.

This commit

- Implement a function in the `base` package for all components to use
- The function supports filling fields with primitive types, including string, integer, number, boolean, and array of them.
- Support allOf, anyOf, oneOf fields
- Recursively fill in multi-layer object value
