### PR TITLE
feat: GitHub component pagination

### DIFF
--- a/application/github/v0/README.mdx
+++ b/application/github/v0/README.mdx
@@ -11,7 +11,7 @@ It can carry out the following tasks:
 - [List Pull Requests](#list-pull-requests)
 - [Get Pull Request](#get-pull-request)
 - [Get Commit](#get-commit)
-- [Get Review Comments](#get-review-comments)
+- [List Review Comments](#list-review-comments)
 - [Create Review Comment](#create-review-comment)
 - [List Issues](#list-issues)
 - [Get Issue](#get-issue)
@@ -58,12 +58,14 @@ Get the list of all pull requests in a repository
 | State | `state` | string | State of the PRs, including open, closed, all. Default is open |
 | Sort | `sort` | string | Sort the PRs by created, updated, popularity, or long-running. Default is created |
 | Direction | `direction` | string | Direction of the sort, including asc or desc. Default is desc |
+| Page | `page` | integer | Page number of the results to fetch. Default is 1 |
+| Per Page | `per-page` | integer | Number of results to fetch per page. Default is 30 |
 
 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Pull Requests | `pull_requests` | array[object] | An array of PRs |
+| Pull Requests | `pull-requests` | array[object] | An array of PRs |
 
 
 
@@ -80,13 +82,24 @@ Get a pull request from a repository, given the PR number. This will default to 
 | Task ID (required) | `task` | string | `TASK_GET_PULL_REQUEST` |
 | Owner (required) | `owner` | string | Owner of the repository |
 | Repository (required) | `repository` | string | Repository name |
-| PR Number | `pr_number` | integer | Number of the PR. `0` for the latest PR |
+| PR Number | `pr-number` | integer | Number of the PR. `0` for the latest PR |
 
 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Pull Request | `pull_request` | object | A pull request in GitHub |
+| PR id (optional) | `id` | integer | id of the PR |
+| PR number (optional) | `number` | integer | number of the PR |
+| PR state (optional) | `state` | string | state of the PR |
+| PR Title (optional) | `title` | string | Title of the PR |
+| PR body (optional) | `body` | string | Body of the PR |
+| PR diff url (optional) | `diff-url` | string | url to the diff of the PR |
+| PR head (optional) | `head` | string | head commit of the PR (in SHA value) |
+| PR base (optional) | `base` | string | base commit of the PR (in SHA value) |
+| Number of PR comments (optional) | `comments-num` | integer | number of comments on the PR |
+| Number of PR commits (optional) | `commits-num` | integer | number of commits in the PR |
+| Number of PR review comments (optional) | `review-comments-num` | integer | number of review comments in the PR |
+| Commits (optional) | `commits` | array[object] | commits in the PR |
 
 
 
@@ -109,27 +122,32 @@ Get a commit from a repository, given the commit SHA
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Commit | `commit` | object | A commit in GitHub |
+| Commit SHA (optional) | `sha` | string | SHA of the commit |
+| Commit message (optional) | `message` | string | message of the commit |
+| Commit stats (optional) | `stats` | object | stats of changes |
+| Files (optional) | `files` | array[object] | files in the commit |
 
 
 
 
 
 
-### Get Review Comments
+### List Review Comments
 
 Get the review comments in a pull request
 
 
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Task ID (required) | `task` | string | `TASK_GET_REVIEW_COMMENTS` |
+| Task ID (required) | `task` | string | `TASK_LIST_REVIEW_COMMENTS` |
 | Owner (required) | `owner` | string | Owner of the repository |
 | Repository (required) | `repository` | string | Repository name |
-| PR Number | `pr_number` | integer | Number of the PR. Default `0` is the latest PR |
+| PR Number | `pr-number` | integer | Number of the PR. Default is `0`, which retrieves all comments on all PRs in the repository |
 | Sort | `sort` | string | Sort the comments by created, updated. Default is created |
 | Direction | `direction` | string | Direction of the sort, including asc or desc. Default is desc |
 | Since | `since` | string | Only comments updated at or after this time are returned. Default is 2021-01-01T00:00:00Z |
+| Page | `page` | integer | Page number of the results to fetch. Default is 1 |
+| Per Page | `per-page` | integer | Number of results to fetch per page. Default is 30 |
 
 
 
@@ -152,14 +170,26 @@ Create a review comment in pull request.
 | Task ID (required) | `task` | string | `TASK_CREATE_REVIEW_COMMENT` |
 | Owner (required) | `owner` | string | Owner of the repository |
 | Repository (required) | `repository` | string | Repository name |
-| PR Number (required) | `pr_number` | integer | Number of the PR |
+| PR Number (required) | `pr-number` | integer | Number of the PR |
 | Comment (required) | `comment` | object | The comment to be added |
 
 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Review Comment | `comment` | object | The created comment |
+| Comment id (optional) | `id` | integer | ID of the comment |
+| In Reply To (optional) | `in-reply-to-id` | integer | ID of the comment this comment is in reply to |
+| Commit SHA (optional) | `commitId` | string | SHA of the commit on which you want to comment |
+| Comment body (optional) | `body` | string | Body of the comment |
+| Comment path (optional) | `path` | string | Path of the file the comment is on |
+| Comment end line (optional) | `line` | integer | The line of the blob in the pull request diff that the comment applies to. For a multi-line comment, the last line of the range that your comment applies to. |
+| Comment start line (optional) | `start-line` | integer | The first line in the pull request diff that your multi-line comment applies to. Only multi-line comment needs to fill this field. |
+| Comment end side (optional) | `side` | string | Side of the end line, can be one of: LEFT, RIGHT, side. LEFT is the left side of the diff (deletion), RIGHT is the right side of the diff (addition), and side is the comment on the PR as a whole. Default is side |
+| Comment start side (optional) | `start-side` | string | Side of the start line, can be one of: LEFT, RIGHT, side. LEFT is the left side of the diff (deletion), RIGHT is the right side of the diff (addition), and side is the comment on the PR as a whole. Default is side |
+| Comment type (optional) | `subject-type` | string | Subject type of the comment, can be one of: line, file. Default is line |
+| Comment created at (optional) | `created-at` | string | Time the comment was created |
+| Comment updated at (optional) | `updated-at` | string | Time the comment was updated |
+| User (optional) | `user` | object | User who created the comment |
 
 
 
@@ -180,7 +210,9 @@ Get the list of all issues in a repository
 | Sort | `sort` | string | Sort the issues by created, updated, popularity, or long-running. Default is created |
 | Direction | `direction` | string | Direction of the sort, can be one of: asc, desc. Default is desc |
 | Since | `since` | string | Only issues updated at or after this time are returned. Default is 2021-01-01T00:00:00Z |
-| No Pull Request | `no_pull_request` | boolean | Whether to not include pull requests in the issues. Default is false |
+| No Pull Request | `no-pull-request` | boolean | Whether to `not` include pull requests in the response. Since issue and pr use the same indexing system in GitHub, the API returns all relevant objects (issues and pr). Default is false |
+| Page | `page` | integer | Page number of the results to fetch. Default is 1 |
+| Per Page | `per-page` | integer | Number of results to fetch per page. Default is 30 |
 
 
 
@@ -203,13 +235,20 @@ Get an issue.
 | Task ID (required) | `task` | string | `TASK_GET_ISSUE` |
 | Owner (required) | `owner` | string | Owner of the repository |
 | Repository (required) | `repository` | string | Repository name |
-| Issue Number (required) | `issue_number` | integer | Number of the issue |
+| Issue Number (required) | `issue-number` | integer | Number of the issue |
 
 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Issue | `issue` | object | An issue in GitHub |
+| Issue number (optional) | `number` | integer | Number of the issue |
+| Issue state (optional) | `state` | string | State of the issue |
+| Issue title (optional) | `title` | string | Title of the issue |
+| Issue body (optional) | `body` | string | Body of the issue |
+| Assignee (optional) | `assignee` | string | Assignee of the issue |
+| Assignees (optional) | `assignees` | array[string] | Assignees of the issue |
+| Labels (optional) | `labels` | array[string] | Labels of the issue |
+| Is Pull Request (optional) | `is-pull-request` | boolean | Whether the issue is a pull request |
 
 
 
@@ -231,7 +270,14 @@ Get an issue.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Issue | `issue` | object | The created issue |
+| Issue number (optional) | `number` | integer | Number of the issue |
+| Issue state (optional) | `state` | string | State of the issue |
+| Issue title (optional) | `title` | string | Title of the issue |
+| Issue body (optional) | `body` | string | Body of the issue |
+| Assignee (optional) | `assignee` | string | Assignee of the issue |
+| Assignees (optional) | `assignees` | array[string] | Assignees of the issue |
+| Labels (optional) | `labels` | array[string] | Labels of the issue |
+| Is Pull Request (optional) | `is-pull-request` | boolean | Whether the issue is a pull request |
 
 
 
@@ -246,17 +292,21 @@ Get an issue.
 | Task ID (required) | `task` | string | `TASK_CREATE_WEBHOOK` |
 | Owner (required) | `owner` | string | Owner of the repository |
 | Repository (required) | `repository` | string | Repository name |
-| Webhook URL (required) | `hook_url` | string | URL to send the payload to |
+| Webhook URL (required) | `hook-url` | string | URL to send the payload to |
 | Events (required) | `events` | array[string] | Events to trigger the webhook. Please see https://docs.github.com/en/webhooks/webhook-events-and-payloads for more information |
 | Active | `active` | boolean | Whether the webhook is active. Default is false |
-| Content Type | `content_type` | string | Content type of the webhook, can be one of: json, form. Default is json |
-| Hook Secret | `hook_secret` | string | If provided, the secret will be used as the key to generate the HMAC hex digest value for delivery signature headers. (see https://docs.github.com/en/webhooks/webhook-events-and-payloads#delivery-headers) |
+| Content Type | `content-type` | string | Content type of the webhook, can be one of: json, form. Default is json |
+| Hook Secret | `hook-secret` | string | If provided, the secret will be used as the key to generate the HMAC hex digest value for delivery signature headers. (see https://docs.github.com/en/webhooks/webhook-events-and-payloads#delivery-headers) |
 
 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Webhook | `hook` | object | The created webhook |
+| Webhook ID (optional) | `id` | integer | ID of the webhook |
+| Webhook URL (optional) | `url` | string | URL of the webhook |
+| Ping URL (optional) | `ping-url` | string | URL to ping the webhook |
+| Test URL (optional) | `test-url` | string | URL to test the webhook |
+| Config (optional) | `config` | object | Configuration of the webhook |
 
 
 

--- a/application/github/v0/config/tasks.json
+++ b/application/github/v0/config/tasks.json
@@ -428,6 +428,43 @@
       },
       "title": "Issue",
       "type": "object"
+    },
+    "page-options": {
+      "title": "Page Options",
+      "description": "Options for listing pages",
+      "instillFormat": "object",
+      "type": "object",
+      "required": [],
+      "page": {
+        "default": 1,
+        "description": "Page number of the results to fetch. Default is 1",
+        "instillUIOrder": 100,
+        "title": "Page",
+        "instillFormat": "integer",
+        "instillAcceptFormats": [
+          "integer"
+        ],
+        "instillUpstreamTypes": [
+          "value",
+          "reference"
+        ],
+        "type": "integer"
+      },
+      "per-page": {
+        "default": 30,
+        "description": "Number of results to fetch per page. Default is 30",
+        "instillUIOrder": 101,
+        "title": "Per Page",
+        "instillFormat": "integer",
+        "instillAcceptFormats": [
+          "integer"
+        ],
+        "instillUpstreamTypes": [
+          "value",
+          "reference"
+        ],
+        "type": "integer"
+      }
     }
   },
   "TASK_LIST_PULL_REQUESTS": {
@@ -501,6 +538,36 @@
           ],
           "instillUIOrder": 12,
           "type": "string"
+        },
+        "page": {
+          "default": 1,
+          "description": "Page number of the results to fetch. Default is 1",
+          "instillUIOrder": 100,
+          "title": "Page",
+          "instillFormat": "integer",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "type": "integer"
+        },
+        "per-page": {
+          "default": 30,
+          "description": "Number of results to fetch per page. Default is 30",
+          "instillUIOrder": 101,
+          "title": "Per Page",
+          "instillFormat": "integer",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "type": "integer"
         }
       },
       "required": [
@@ -662,6 +729,36 @@
           ],
           "instillUIOrder": 13,
           "type": "string"
+        },
+        "page": {
+          "default": 1,
+          "description": "Page number of the results to fetch. Default is 1",
+          "instillUIOrder": 100,
+          "title": "Page",
+          "instillFormat": "integer",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "type": "integer"
+        },
+        "per-page": {
+          "default": 30,
+          "description": "Number of results to fetch per page. Default is 30",
+          "instillUIOrder": 101,
+          "title": "Per Page",
+          "instillFormat": "integer",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "type": "integer"
         }
       },
       "required": [
@@ -931,6 +1028,36 @@
           ],
           "instillUIOrder": 14,
           "type": "boolean"
+        },
+        "page": {
+          "default": 1,
+          "description": "Page number of the results to fetch. Default is 1",
+          "instillUIOrder": 100,
+          "title": "Page",
+          "instillFormat": "integer",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "type": "integer"
+        },
+        "per-page": {
+          "default": 30,
+          "description": "Number of results to fetch per page. Default is 30",
+          "instillUIOrder": 101,
+          "title": "Per Page",
+          "instillFormat": "integer",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "type": "integer"
         }
       },
       "required": [

--- a/application/github/v0/issues.go
+++ b/application/github/v0/issues.go
@@ -79,6 +79,7 @@ type ListIssuesInput struct {
 	Direction     string `json:"direction"`
 	Since         string `json:"since"`
 	NoPullRequest bool   `json:"no-pull-request"`
+	PageOptions
 }
 
 type ListIssuesResp struct {
@@ -105,6 +106,10 @@ func (githubClient *Client) listIssuesTask(ctx context.Context, props *structpb.
 		Sort:      inputStruct.Sort,
 		Direction: inputStruct.Direction,
 		Since:     *sinceTime,
+		ListOptions: github.ListOptions{
+			Page:    inputStruct.Page,
+			PerPage: min(inputStruct.PerPage, 100), // GitHub API only allows 100 per page
+		},
 	}
 	if opts.Mentioned == "none" {
 		opts.Mentioned = ""

--- a/application/github/v0/pull_request.go
+++ b/application/github/v0/pull_request.go
@@ -67,6 +67,7 @@ type ListPullRequestsInput struct {
 	State     string `json:"state"`
 	Sort      string `json:"sort"`
 	Direction string `json:"direction"`
+	PageOptions
 }
 type ListPullRequestsResp struct {
 	PullRequests []PullRequest `json:"pull-requests"`
@@ -88,6 +89,10 @@ func (githubClient *Client) listPullRequestsTask(ctx context.Context, props *str
 		State:     inputStruct.State,
 		Sort:      inputStruct.Sort,
 		Direction: inputStruct.Direction,
+		ListOptions: github.ListOptions{
+			Page:    inputStruct.Page,
+			PerPage: min(inputStruct.PerPage, 100), // GitHub API only allows 100 per page
+		},
 	}
 	prs, _, err := githubClient.PullRequests.List(ctx, owner, repository, opts)
 	if err != nil {
@@ -145,6 +150,10 @@ func (githubClient *Client) getPullRequestTask(ctx context.Context, props *struc
 			State:     "all",
 			Sort:      "created",
 			Direction: "desc",
+			ListOptions: github.ListOptions{
+				Page:    1,
+				PerPage: 1,
+			},
 		}
 		prs, _, err := githubClient.PullRequests.List(ctx, owner, repository, opts)
 		if err != nil {

--- a/application/github/v0/review_comment.go
+++ b/application/github/v0/review_comment.go
@@ -26,6 +26,7 @@ type ListReviewCommentsInput struct {
 	Sort      string `json:"sort"`
 	Direction string `json:"direction"`
 	Since     string `json:"since"`
+	PageOptions
 }
 
 type ListReviewCommentsResp struct {
@@ -56,6 +57,10 @@ func (githubClient *Client) listReviewCommentsTask(ctx context.Context, props *s
 		Sort:      inputStruct.Sort,
 		Direction: inputStruct.Direction,
 		Since:     *sinceTime,
+		ListOptions: github.ListOptions{
+			Page:    inputStruct.Page,
+			PerPage: min(inputStruct.PerPage, 100), // GitHub API only allows 100 per page
+		},
 	}
 	number := inputStruct.PrNumber
 	comments, _, err := githubClient.PullRequests.ListComments(ctx, owner, repository, number, opts)

--- a/application/github/v0/utils.go
+++ b/application/github/v0/utils.go
@@ -7,6 +7,11 @@ import (
 	"github.com/instill-ai/x/errmsg"
 )
 
+type PageOptions struct {
+	Page    int `json:"page"`
+	PerPage int `json:"per-page"`
+}
+
 func middleWare(req string) int {
 	if req == "rate_limit" {
 		return 403


### PR DESCRIPTION
Because

- Users may want to control how much data they wish to receive.

This commit

- Add pagination options to all list tasks
- Update readme
