### PR TITLE
chore(mistral): fix the import ID for Instill Credential

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -109,10 +109,11 @@ func Init(
 			conn = conn.WithInstillCredentials(secrets[conn.GetDefinitionID()])
 			compStore.Import(conn)
 		}
-    {
+		{
 			// Mistral
 			conn := mistralai.Init(baseComp)
-			conn = conn.WithInstillCredentials(secrets[conn.GetDefinitionID()])
+			// Secret doesn't allow hyphens
+			conn = conn.WithInstillCredentials(secrets["mistralai"])
 			compStore.Import(conn)
 		}
 		{


### PR DESCRIPTION
Because

- We don't allow hyphens in the component ID when initiating the Instill Credential.

This commit

- Fixes the import ID for Instill Credential.