### PR TITLE
fix: fix instillUpstreamTypes not correctly render the JSON schema

### DIFF
--- a/base/component.go
+++ b/base/component.go
@@ -159,7 +159,7 @@ func convertDataSpecToCompSpec(dataSpec *structpb.Struct) (*structpb.Struct, err
 					if err != nil {
 						return nil, err
 					}
-					compSpec.Fields[target].GetListValue().AsSlice()[idx] = structpb.NewStructValue(converted)
+					compSpec.Fields[target].GetListValue().Values[idx] = structpb.NewStructValue(converted)
 				}
 			}
 		}


### PR DESCRIPTION
Because

- The instillUpstreamTypes do not correctly render the JSON schema when it is under `anyOf`, `oneOf`, or `allOf`.

This commit

- Fixes the bug.