### PR TITLE
fix(text): hotfix the bug from langchaingo without importing the function o…

### DIFF
--- a/operator/text/v0/.compogen/extra-chunk-text.mdx
+++ b/operator/text/v0/.compogen/extra-chunk-text.mdx
@@ -36,7 +36,6 @@ This text splitter is specially designed for Markdown format.
 | `chunk-overlap`    | integer  | Determines the number of tokens that overlap between consecutive chunks                                                                                                                                      |
 | `model-name`       | string   | The name of the model used for tokenization                                                                                                                                                                  |
 | `code-blocks`      | boolean  | A flag indicating whether code blocks should be treated as a single unit                                                                                                                                     |
-| `reference-links`  | boolean  | A flag indicating whether reference links should be kept intact                                                                                                                                              |
 
 ### Text Chunks in Output
 | **Parameter**    | **Type** | **Description**                                              |

--- a/operator/text/v0/README.mdx
+++ b/operator/text/v0/README.mdx
@@ -111,7 +111,6 @@ This text splitter is specially designed for Markdown format.
 | `chunk-overlap`    | integer  | Determines the number of tokens that overlap between consecutive chunks                                                                                                                                      |
 | `model-name`       | string   | The name of the model used for tokenization                                                                                                                                                                  |
 | `code-blocks`      | boolean  | A flag indicating whether code blocks should be treated as a single unit                                                                                                                                     |
-| `reference-links`  | boolean  | A flag indicating whether reference links should be kept intact                                                                                                                                              |
 
 ### Text Chunks in Output
 | **Parameter**    | **Type** | **Description**                                              |

--- a/operator/text/v0/chunk_text.go
+++ b/operator/text/v0/chunk_text.go
@@ -27,7 +27,6 @@ type Setting struct {
 	Separators        []string `json:"separators,omitempty"`
 	KeepSeparator     bool     `json:"keep-separator,omitempty"`
 	CodeBlocks        bool     `json:"code-blocks,omitempty"`
-	ReferenceLinks    bool     `json:"reference-links,omitempty"`
 	// TODO: Add SecondSplitter, which is to set the details about how to chunk the paragraphs in Markdown format.
 	// https://pkg.go.dev/github.com/tmc/langchaingo@v0.1.10/textsplitter#MarkdownTextSplitter
 	// secondSplitter textsplitter.TextSplitter
@@ -97,7 +96,6 @@ func chunkText(input ChunkTextInput) (ChunkTextOutput, error) {
 			textsplitter.WithChunkSize(setting.ChunkSize),
 			textsplitter.WithChunkOverlap(setting.ChunkOverlap),
 			textsplitter.WithCodeBlocks(setting.CodeBlocks),
-			textsplitter.WithReferenceLinks(setting.ReferenceLinks),
 		)
 	case "Recursive":
 		positionCalculator = PositionCalculator{}

--- a/operator/text/v0/config/tasks.json
+++ b/operator/text/v0/config/tasks.json
@@ -351,20 +351,6 @@
                       ],
                       "title": "Code Blocks",
                       "type": "boolean"
-                    },
-                    "reference-links": {
-                      "description": "A flag indicating whether reference links should be kept intact",
-                      "instillAcceptFormats": [
-                        "boolean"
-                      ],
-                      "instillUIOrder": 4,
-                      "instillUpstreamTypes": [
-                        "value",
-                        "reference",
-                        "template"
-                      ],
-                      "title": "Reference Links",
-                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -375,8 +361,7 @@
                     "chunk-size",
                     "chunk-overlap",
                     "model-name",
-                    "code-blocks",
-                    "reference-links"
+                    "code-blocks"
                   ],
                   "type": "object"
                 }


### PR DESCRIPTION
Because

- there is a bug in langchaingo with reference link

This commit

- take out reference link in vdp

Decision logic
- langchaingo invented this [ReferenceLink](https://pkg.go.dev/github.com/tmc/langchaingo@v0.1.10/textsplitter#WithReferenceLinks) on their own.
  - Now, it seems there is a bug in [langchaingo package](https://pkg.go.dev/github.com/tmc/langchaingo@v0.1.10/textsplitter#WithReferenceLinks), which will take longer time to fix this error.
- Given we will fix Markdown Splitter in the future plan, and the plan will be like
  - Now, we use [markdown splitter in langchaingo](https://pkg.go.dev/github.com/tmc/langchaingo@v0.1.10/textsplitter#MarkdownTextSplitter).
  - In the future, we will use [markdown header splitter in langchain](https://python.langchain.com/v0.2/docs/how_to/markdown_header_metadata_splitter/).
- So, we fix this error by the solution above.