### PR TITLE
chore: use kebab-case in JSON operator

### DIFF
--- a/operator/json/v0/README.mdx
+++ b/operator/json/v0/README.mdx
@@ -81,8 +81,7 @@ Process JSON through a `jq` command
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_JQ` |
 | JSON value | `json-value` | any | JSON value (e.g. string, number, object, array...) to be processed by the filter |
-| Filter (required) | `jqFilter` | string | Filter, in `jq` syntax, that will be applied to the JSON input |
-| (DEPRECATED) JSON input | `jsonInput` | string | (DEPRECATED, use 'JSON value' instead) JSON string to be processed. This field allows templated inputs, but the data might preprocessing (marshalling). This field will be used in absence of 'JSON value' for backwards compatibility reasons. |
+| Filter (required) | `jq-filter` | string | Filter, in `jq` syntax, that will be applied to the JSON input |
 
 
 

--- a/operator/json/v0/component_test.go
+++ b/operator/json/v0/component_test.go
@@ -93,8 +93,8 @@ func TestOperator_Execute(t *testing.T) {
 
 			task: taskJQ,
 			in: map[string]any{
-				"jsonInput": `{"a": {"b": 42}}`,
-				"jqFilter":  ".a | .[]",
+				"json-string": `{"a": {"b": 42}}`,
+				"jq-filter":   ".a | .[]",
 			},
 			want: map[string]any{
 				"results": []any{42},
@@ -105,8 +105,8 @@ func TestOperator_Execute(t *testing.T) {
 
 			task: taskJQ,
 			in: map[string]any{
-				"jsonInput": "{",
-				"jqFilter":  ".",
+				"json-string": "{",
+				"jq-filter":   ".",
 			},
 			wantErr: "Couldn't parse the JSON input. Please check the syntax is correct.",
 		},
@@ -116,7 +116,7 @@ func TestOperator_Execute(t *testing.T) {
 			task: taskJQ,
 			in: map[string]any{
 				"json-value": "foo",
-				"jqFilter":   `. + "bar"`,
+				"jq-filter":  `. + "bar"`,
 			},
 			want: map[string]any{
 				"results": []any{"foobar"},
@@ -128,7 +128,7 @@ func TestOperator_Execute(t *testing.T) {
 			task: taskJQ,
 			in: map[string]any{
 				"json-value": []any{2, 3, 23},
-				"jqFilter":   ".[2]",
+				"jq-filter":  ".[2]",
 			},
 			want: map[string]any{
 				"results": []any{23},
@@ -143,7 +143,7 @@ func TestOperator_Execute(t *testing.T) {
 					"id": "sample",
 					"10": map[string]any{"b": 42},
 				},
-				"jqFilter": `{(.id): .["10"].b}`,
+				"jq-filter": `{(.id): .["10"].b}`,
 			},
 			want: map[string]any{
 				"results": []any{
@@ -156,8 +156,8 @@ func TestOperator_Execute(t *testing.T) {
 
 			task: taskJQ,
 			in: map[string]any{
-				"jsonInput": asJSON,
-				"jqFilter":  ".foo & .bar",
+				"json-string": asJSON,
+				"jq-filter":   ".foo & .bar",
 			},
 			wantErr: `Couldn't parse the jq filter: unexpected token "&". Please check the syntax is correct.`,
 		},

--- a/operator/json/v0/config/tasks.json
+++ b/operator/json/v0/config/tasks.json
@@ -114,9 +114,10 @@
       "description": "Source JSON and jq command",
       "instillUIOrder": 0,
       "properties": {
-        "jsonInput": {
+        "json-string": {
+          "deprecated": true,
           "instillUIOrder": 2,
-          "description": "(DEPRECATED, use 'JSON value' instead) JSON string to be processed. This field allows templated inputs, but the data might preprocessing (marshalling). This field will be used in absence of 'JSON value' for backwards compatibility reasons.",
+          "description": "(DEPRECATED, use 'JSON value' instead) String with the JSON value to be processed. This field allows templated inputs, but the data might require preprocessing (marshalling). This field will be used in absence of 'JSON value' for backwards compatibility reasons.",
           "instillShortDescription": "(DEPRECATED) JSON string to be processed",
           "instillAcceptFormats": [
             "string"
@@ -127,7 +128,7 @@
             "template"
           ],
           "instillUIMultiline": true,
-          "title": "(DEPRECATED) JSON input",
+          "title": "(DEPRECATED) JSON string",
           "type": "string"
         },
         "json-value": {
@@ -145,7 +146,7 @@
           "instillUIMultiline": true,
           "title": "JSON value"
         },
-        "jqFilter": {
+        "jq-filter": {
           "instillUIOrder": 1,
           "description": "Filter, in `jq` syntax, that will be applied to the JSON input",
           "instillAcceptFormats": [
@@ -162,11 +163,11 @@
         }
       },
       "required": [
-        "jqFilter"
+        "jq-filter"
       ],
       "instillEditOnNodeFields": [
         "json-value",
-        "jqFilter"
+        "jq-filter"
       ],
       "title": "Input",
       "type": "object"

--- a/operator/json/v0/main.go
+++ b/operator/json/v0/main.go
@@ -110,13 +110,13 @@ func (e *execution) jq(in *structpb.Struct) (*structpb.Struct, error) {
 
 	input := in.Fields["json-value"].AsInterface()
 	if input == nil {
-		b := []byte(in.Fields["jsonInput"].GetStringValue())
+		b := []byte(in.Fields["json-string"].GetStringValue())
 		if err := json.Unmarshal(b, &input); err != nil {
 			return nil, errmsg.AddMessage(err, "Couldn't parse the JSON input. Please check the syntax is correct.")
 		}
 	}
 
-	queryStr := in.Fields["jqFilter"].GetStringValue()
+	queryStr := in.Fields["jq-filter"].GetStringValue()
 	q, err := gojq.Parse(queryStr)
 	if err != nil {
 		// Error messages from gojq are human-friendly enough.

--- a/tools/compogen/cmd/root.go
+++ b/tools/compogen/cmd/root.go
@@ -9,10 +9,14 @@ import (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:     "compogen",
-	Short:   "compogen is the Instill AI component schema generation tool",
-	Long:    "compogen is the Instill AI component schema generation tool",
-	Version: "0.1.1",
+	Use:   "compogen",
+	Short: "compogen is the Instill AI component schema generation tool",
+	Long:  "compogen is the Instill AI component schema generation tool",
+
+	// TODO jvallesm: this should be automatically set according to repo
+	// releases.
+	Version: "0.1.2",
+
 	// We print errors ourselves rather than letting Cobra do it.
 	// This lets us print usage information selectively.
 	SilenceErrors: true,

--- a/tools/compogen/cmd/testdata/readme-operator.txt
+++ b/tools/compogen/cmd/testdata/readme-operator.txt
@@ -51,6 +51,13 @@ cmp pkg/dummy/README.mdx want-readme.mdx
           "instillUIOrder": 0,
           "title": "Durna",
           "type": "string"
+        },
+        "parra": {
+          "deprecated": true,
+          "description": "Shouldn't appear, it's deprecated",
+          "instillUIOrder": 1,
+          "title": "Parra",
+          "type": "string"
         }
       },
       "required": [

--- a/tools/compogen/cmd/testdata/usage.txt
+++ b/tools/compogen/cmd/testdata/usage.txt
@@ -15,7 +15,7 @@ cmp stdout want-help
 cmp stderr want-usage
 
 -- want-version --
-compogen version 0.1.1
+compogen version 0.1.2
 -- want-usage --
 Error: unknown flag: --unknown
 Run 'compogen --help' for usage.

--- a/tools/compogen/pkg/gen/readme.go
+++ b/tools/compogen/pkg/gen/readme.go
@@ -292,6 +292,10 @@ func parseResourceProperties(o *objectSchema) []resourceProperty {
 	// transform it to a slice.
 	propMap := make(map[string]resourceProperty)
 	for k, op := range o.Properties {
+		if op.Deprecated {
+			continue
+		}
+
 		prop := resourceProperty{
 			ID:       k,
 			property: op,
@@ -319,11 +323,11 @@ func parseResourceProperties(o *objectSchema) []resourceProperty {
 		}
 	}
 
-	props := make([]resourceProperty, len(o.Properties))
+	props := make([]resourceProperty, len(propMap))
 	idx := 0
 	for k := range propMap {
 		props[idx] = propMap[k]
-		idx += 1
+		idx++
 	}
 
 	// Note: The order might not be consecutive numbers.

--- a/tools/compogen/pkg/gen/schema.go
+++ b/tools/compogen/pkg/gen/schema.go
@@ -11,6 +11,8 @@ type property struct {
 	Items struct {
 		Type string `json:"type"`
 	} `json:"items"`
+
+	Deprecated bool `json:"deprecated"`
 }
 
 type objectSchema struct {


### PR DESCRIPTION
Because

- Migration to `kebab-case` didn't include JQ task in JSON operator.

This commit

- Updates JQ input fields with `kebab-case` names.
- Updates `compogen` to ignore deprecated fields.
