### PR TITLE
fix(restapi): fix response body missing problem

### DIFF
--- a/application/restapi/v0/main.go
+++ b/application/restapi/v0/main.go
@@ -152,6 +152,13 @@ func (e *execution) Execute(_ context.Context, inputs []*structpb.Struct) ([]*st
 		taskOut.StatusCode = resp.StatusCode()
 		taskOut.Header = resp.Header()
 
+		if taskOut.Body == nil {
+			// Maintain a JSON structure for the output to avoid frontend render overhead.
+			taskOut.Body = map[string]interface{}{
+				"response": resp.String(),
+			}
+		}
+
 		output, err := base.ConvertToStructpb(taskOut)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Because

- `restapi` component would miss the response body if it is not a JSON

This commit

- check whether the body is nil, if true, assign the response as a string
- maintain body in JSON structure to avoid frontend render overhead
  - as the frontend would split the plain text into thousands of div if the body is large