### PR TITLE
chore: improve JSON operator documentation

### DIFF
--- a/operator/json/v0/.compogen/extra-jq.mdx
+++ b/operator/json/v0/.compogen/extra-jq.mdx
@@ -1,0 +1,15 @@
+[`jq`](https://jqlang.github.io/jq/) defines a syntax to "transform JSON in
+various ways, by selecting, iterating, reducing and otherwise mangling JSON
+documents". Depending on the command input and the `jq` filter, the type and
+shape of the results may vary.
+
+Here are some examples on how the `jq` syntax works.
+
+| Input JSON | `jq` filter | Output |
+| :--- | :--- | :--- |
+| `{"foo": 128}` | `.foo` | `[128]` |
+| `{"a": {"b": 42}}` | `.a.b` | `[42]` |
+| `{"id": "sample", "10": {"b": 42}}` | `{(.id): .["10"].b}` | `[{ "sample": 42 }]` |
+| `[{"id":1},{"id":2},{"id":3}]` | `.[] \| .id` | `[1, 2, 3]` |
+| `{"a":1,"b":2}` | `.a += 1 \| .b *= 2` | `[{ "a": 2, "b": 4 }]` |
+| `{"a":1} [2] 3` | `. as {$a} ?// [$a] ?// $a \| $a` | `[1, 2, 3]` |

--- a/operator/json/v0/README.mdx
+++ b/operator/json/v0/README.mdx
@@ -5,7 +5,7 @@ draft: false
 description: "Learn about how to set up a VDP JSON component https://github.com/instill-ai/instill-core"
 ---
 
-The JSON component is an operator component that allows users to manipulate and convert JSON objects.
+The JSON component is an operator component that allows users to manipulate and convert JSON entities.
 It can carry out the following tasks:
 
 - [Marshal](#marshal)
@@ -38,7 +38,7 @@ Convert JSON to a string
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_MARSHAL` |
-| JSON (required) | `json` | any | JSON input to be marshaled |
+| JSON (required) | `json` | any | JSON entity to be marshaled. It can be any valid JSON datatype (e.g. number, string, hash, array). |
 
 
 
@@ -59,13 +59,13 @@ Convert a string to JSON
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_UNMARSHAL` |
-| String (required) | `string` | string | JSON string to be unmarshaled |
+| String (required) | `string` | string | JSON string to be unmarshaled. It can represent any valid JSON datatype (e.g. number, string, hash, array). |
 
 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| JSON | `json` | any | JSON object extracted from the string input |
+| JSON | `json` | any | JSON entity extracted from the string input |
 
 
 
@@ -80,16 +80,31 @@ Process JSON through a `jq` command
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_JQ` |
-| JSON value | `json-value` | any | JSON value (e.g. string, number, object, array...) to be processed by the filter |
+| JSON value | `json-value` | any | JSON entity to be processed by the filter. It can be any valid JSON datatype (e.g. number, string, hash, array). |
 | Filter (required) | `jq-filter` | string | Filter, in `jq` syntax, that will be applied to the JSON input |
 
 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Results | `results` | array | The `jq` command results. Depending on the filter and the input JSON the type of each element may vary. |
+| Results | `results` | array | The `jq` command results |
 
 
+[`jq`](https://jqlang.github.io/jq/) defines a syntax to "transform JSON in
+various ways, by selecting, iterating, reducing and otherwise mangling JSON
+documents". Depending on the command input and the `jq` filter, the type and
+shape of the results may vary.
+
+Here are some examples on how the `jq` syntax works.
+
+| Input JSON | `jq` filter | Output |
+| :--- | :--- | :--- |
+| `{"foo": 128}` | `.foo` | `[128]` |
+| `{"a": {"b": 42}}` | `.a.b` | `[42]` |
+| `{"id": "sample", "10": {"b": 42}}` | `{(.id): .["10"].b}` | `[{ "sample": 42 }]` |
+| `[{"id":1},{"id":2},{"id":3}]` | `.[] \| .id` | `[1, 2, 3]` |
+| `{"a":1,"b":2}` | `.a += 1 \| .b *= 2` | `[{ "a": 2, "b": 4 }]` |
+| `{"a":1} [2] 3` | `. as {$a} ?// [$a] ?// $a \| $a` | `[1, 2, 3]` |
 
 
 

--- a/operator/json/v0/component_test.go
+++ b/operator/json/v0/component_test.go
@@ -47,6 +47,13 @@ func TestOperator_Execute(t *testing.T) {
 			wantJSON: json.RawMessage(asJSON),
 		},
 		{
+			name: "ok - marshal string",
+
+			task:     taskMarshal,
+			in:       map[string]any{"json": "dos"},
+			wantJSON: json.RawMessage(`"dos"`),
+		},
+		{
 			name: "ok - marshal array",
 
 			task:     taskMarshal,
@@ -186,7 +193,7 @@ func TestOperator_Execute(t *testing.T) {
 			if tc.wantJSON != nil {
 				// Check JSON in the output string.
 				b := got[0].Fields["string"].GetStringValue()
-				c.Check([]byte(b), qt.JSONEquals, tc.wantJSON, qt.Commentf(string(b)+" vs "+string(tc.wantJSON)))
+				c.Check([]byte(b), qt.JSONEquals, tc.wantJSON)
 				return
 			}
 

--- a/operator/json/v0/config/definition.json
+++ b/operator/json/v0/config/definition.json
@@ -16,6 +16,6 @@
   "uid": "28f53d15-6150-46e6-99aa-f76b70a926c0",
   "version": "0.1.0",
   "sourceUrl": "https://github.com/instill-ai/component/blob/main/operator/json/v0",
-  "description": "Manipulate and convert JSON objects",
+  "description": "Manipulate and convert JSON entities",
   "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/operator/json/v0/config/tasks.json
+++ b/operator/json/v0/config/tasks.json
@@ -9,7 +9,8 @@
       "instillUIOrder": 0,
       "properties": {
         "json": {
-          "description": "JSON input to be marshaled",
+          "description": "JSON entity to be marshaled. It can be any valid JSON datatype (e.g. number, string, hash, array).",
+          "instillShortDescription": "JSON entity to be marshaled",
           "instillAcceptFormats": [
             "object",
             "semi-structured/*",
@@ -63,7 +64,8 @@
       "instillUIOrder": 0,
       "properties": {
         "string": {
-          "description": "JSON string to be unmarshaled",
+          "description": "JSON string to be unmarshaled. It can represent any valid JSON datatype (e.g. number, string, hash, array).",
+          "instillShortDescription": "JSON string to be unmarshaled",
           "instillAcceptFormats": [
             "string"
           ],
@@ -92,7 +94,7 @@
       "instillUIOrder": 0,
       "properties": {
         "json": {
-          "description": "JSON object extracted from the string input",
+          "description": "JSON entity extracted from the string input",
           "instillEditOnNodeFields": [],
           "instillFormat": "semi-structured/json",
           "instillUIOrder": 0,
@@ -111,7 +113,7 @@
     "instillShortDescription": "Process JSON through a `jq` command",
     "title": "jq",
     "input": {
-      "description": "Source JSON and jq command",
+      "description": "Source JSON and `jq` command",
       "instillUIOrder": 0,
       "properties": {
         "json-string": {
@@ -133,7 +135,7 @@
         },
         "json-value": {
           "instillUIOrder": 0,
-          "description": "JSON value (e.g. string, number, object, array...) to be processed by the filter",
+          "description": "JSON entity to be processed by the filter. It can be any valid JSON datatype (e.g. number, string, hash, array).",
           "instillAcceptFormats": [
             "object",
             "structured/*",
@@ -177,7 +179,7 @@
       "instillUIOrder": 0,
       "properties": {
         "results": {
-          "description": "The `jq` command results. Depending on the filter and the input JSON the type of each element may vary.",
+          "description": "The `jq` command results",
           "instillEditOnNodeFields": [],
           "instillUIOrder": 0,
           "required": [],

--- a/operator/json/v0/main.go
+++ b/operator/json/v0/main.go
@@ -1,4 +1,4 @@
-//go:generate compogen readme ./config ./README.mdx
+//go:generate compogen readme ./config ./README.mdx --extraContents TASK_JQ=.compogen/extra-jq.mdx
 package json
 
 import (


### PR DESCRIPTION
Because

- JSON operator documentation could be clearer.

This commit

- Replaces "JSON object" by "JSON entity" in order to reflect that any JSON datatype is accepted. Technically "object" is valid but it might be confused with the JSON hash type.
- Adds an extra section to document `jq` and share some examples.
