### PR TITLE
fix: fix markdown chunking bugs

### DIFF
--- a/operator/text/v0/chunk_text.go
+++ b/operator/text/v0/chunk_text.go
@@ -153,6 +153,7 @@ func chunkText(input ChunkTextInput) (ChunkTextOutput, error) {
 			StartPosition: 0,
 			EndPosition:   len(rawRunes) - 1,
 		})
+		output.ChunkNum = 1
 	}
 	return output, nil
 }

--- a/operator/text/v0/markdown_splitter.go
+++ b/operator/text/v0/markdown_splitter.go
@@ -280,19 +280,21 @@ func isHashtagInContent(position int, rawRunes []rune) bool {
 	breakChar := string(rawRunes[position-1])
 	if string(rawRunes[position-1]) == "#" {
 		hashTagCount++
-		for i := position - 2; i >= 0; i-- {
-			if string(rawRunes[i]) == "#" {
+		position = position - 2
+		for position >= 0 {
+			if string(rawRunes[position]) == "#" {
 				hashTagCount++
 			} else {
-				breakChar = string(rawRunes[i])
+				breakChar = string(rawRunes[position])
 				break
 			}
+			position--
 		}
 	}
 	if hashTagCount > 6 {
 		return true
 	}
-	if breakChar == "\n" {
+	if breakChar == "\n" || position == -1 {
 		return false
 	}
 	return true

--- a/operator/text/v0/markdown_splitter.go
+++ b/operator/text/v0/markdown_splitter.go
@@ -76,10 +76,12 @@ func (sp MarkdownTextSplitter) buildDocuments(rawRunes []rune) []MarkdownDocumen
 	for startPosition < len(rawRunes) {
 		document, startPosition = sp.buildDocument(rawRunes, document, startPosition)
 
+		if !isBlankDocument(document) {
+			documents = append(documents, document)
+		}
 		if startPosition == 0 {
 			break
 		}
-		documents = append(documents, document)
 	}
 
 	return documents


### PR DESCRIPTION
Because

- we miss to append the final document
- If there is no chunk in split, we make all document as a chunk.
- The definition missed a case for hashtag in header

This commit

- fix the bug to append the final document into the documents
- fix the bug that did not count a chunk as 1
- add the definition in hashtag in header
