### PR TITLE
fix: expose task secret fields

### DIFF
--- a/base/component.go
+++ b/base/component.go
@@ -190,7 +190,7 @@ func convertDataSpecToCompSpec(dataSpec *structpb.Struct) (*structpb.Struct, err
 			newCompSpec.Fields["instillAcceptFormats"] = structpb.NewListValue(compSpec.Fields["instillAcceptFormats"].GetListValue())
 		}
 		newCompSpec.Fields["instillUpstreamTypes"] = structpb.NewListValue(compSpec.Fields["instillUpstreamTypes"].GetListValue())
-		if compSpec.Fields["instillFormat"] != nil {
+		if compSpec.Fields["instillSecret"] != nil {
 			newCompSpec.Fields["instillSecret"] = structpb.NewBoolValue(compSpec.Fields["instillSecret"].GetBoolValue())
 		}
 		newCompSpec.Fields["anyOf"] = structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{}})

--- a/base/component.go
+++ b/base/component.go
@@ -17,7 +17,6 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/instill-ai/component/internal/debug"
 	"github.com/instill-ai/component/internal/jsonref"
 
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
@@ -779,16 +778,6 @@ func (c *Component) initSecretField(def *pb.ComponentDefinition) {
 	}
 	secretFields := []string{}
 
-	verboseLevel := debug.StaticVerboseLevel
-	if t, ok := def.Spec.GetComponentSpecification().GetFields()["title"]; ok {
-		if strings.Contains(t.GetStringValue(), "GitHub") {
-			verboseLevel = debug.DevelopVerboseLevel
-		}
-	}
-	var logger debug.DebugSession
-	logger.SessionStart("initSecretField", verboseLevel)
-	defer logger.SessionEnd()
-	logger.Info("def", def.Spec.GetComponentSpecification().GetFields())
 	setup := def.Spec.GetComponentSpecification().GetFields()["properties"].GetStructValue().GetFields()["setup"].GetStructValue()
 	secretFields = c.traverseSecretField(setup.GetFields()["properties"], "", secretFields)
 	if l, ok := setup.GetFields()["oneOf"]; ok {
@@ -805,7 +794,6 @@ func (c *Component) initSecretField(def *pb.ComponentDefinition) {
 			// secretFields = c.traverseSecretField(input, task+".", secretFields)
 		}
 	}
-	logger.Info(secretFields)
 	c.secretFields = secretFields
 }
 


### PR DESCRIPTION
Because

- Some tasks need task-specific secret fields, which should only be included in the task.
- The current workarounds may harm UX significantly
  - Put it into settings and make it optional. 
    - **cons:** Users might be confused by this irrelevant and non-functioning field when selecting the other tasks.
  - Use "oneOf" and make the setting to a dropdown list. 
    - **cons:** Since we can neither set a default value to the "oneOf" field nor automatically choose the correct value with a specific task, users must choose which setting the task needs and select the correct one every time they create a new component. Thus, users must exert excessive effort to learn how this works.  

This commit

- Expose task secret fields

### Note
We need to adjust the logic of reading secret fields in pipeline-backend and frontend to reference the secret correctly.

1. What can we benefit from this solution?

Make the secret field more flexible.

2. Is there any concern or trade-off if we do this?

We need a thorough investigation and testing to make sure this won't affect existing schema and products.