### PR TITLE
feat: add a debug logger for a better develop experience

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cohere-ai/cohere-go/v2 v2.8.5
 	github.com/emersion/go-imap/v2 v2.0.0-beta.3
 	github.com/emersion/go-message v0.18.1
+	github.com/fatih/color v1.17.0
 	github.com/fogleman/gg v1.3.0
 	github.com/frankban/quicktest v1.14.6
 	github.com/gabriel-vasile/mimetype v1.4.3
@@ -94,6 +95,8 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
+github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -219,6 +221,11 @@ github.com/lestrrat-go/structinfo v0.0.0-20210312050401-7f8bd69d6acb h1:DDg5u5lk
 github.com/lestrrat-go/structinfo v0.0.0-20210312050401-7f8bd69d6acb/go.mod h1:i+E8Uf04vf2QjOWyJdGY75vmG+4rxiZW2kIj1lTB5mo=
 github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 h1:W7p+m/AECTL3s/YR5RpQ4hz5SjNeKzZBl1q36ws12s0=
 github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5/go.mod h1:QMe2wuKJ0o7zIVE8AqiT8rd8epmm6WDIZ2wyuBqYPzM=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
@@ -405,8 +412,10 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/tools/logger/logger.go
+++ b/tools/logger/logger.go
@@ -13,14 +13,14 @@ func (d *Session) Indent() func() *Session {
 
 // Separator adds a separator line
 func (d *Session) Separator() {
-	if Verbose < d.verboseLevel {
+	if d.verboseLevel < Static {
 		return
 	}
 	d.messages = append(d.messages, strings.Repeat("=", d.halfBannerLen*2+len(d.sessionID)+2))
 }
 
 func (d *Session) flush() {
-	if Verbose < d.verboseLevel {
+	if d.verboseLevel < Static {
 		return
 	}
 	if len(d.messages) == 0 {
@@ -60,7 +60,7 @@ func (d *Session) autoPrint(msg ...interface{}) {
 
 // Info logs messages with black color
 func (d *Session) Info(msg ...interface{}) {
-	if Verbose < d.verboseLevel {
+	if d.verboseLevel < Develop {
 		return
 	}
 	defer d.flush()
@@ -68,14 +68,9 @@ func (d *Session) Info(msg ...interface{}) {
 	d.autoPrint(msg...)
 }
 
-// Alias for Info
-func (d *Session) Message(msg ...interface{}) {
-	d.Info(msg...)
-}
-
 // Success logs messages with green color
 func (d *Session) Success(msg ...interface{}) {
-	if Verbose < d.verboseLevel {
+	if d.verboseLevel < Error {
 		return
 	}
 	defer d.flush()
@@ -85,7 +80,7 @@ func (d *Session) Success(msg ...interface{}) {
 
 // Warn logs messages with yellow color
 func (d *Session) Warn(msg ...interface{}) {
-	if Verbose < d.verboseLevel {
+	if d.verboseLevel < Warn {
 		return
 	}
 	defer d.flush()
@@ -95,7 +90,7 @@ func (d *Session) Warn(msg ...interface{}) {
 
 // Error logs messages with red color
 func (d *Session) Error(msg ...interface{}) {
-	if Verbose < d.verboseLevel {
+	if d.verboseLevel < Error {
 		return
 	}
 	defer d.flush()
@@ -105,7 +100,7 @@ func (d *Session) Error(msg ...interface{}) {
 
 // Log messages without expanding them
 func (d *Session) Raw(msg ...interface{}) {
-	if Verbose < d.verboseLevel {
+	if d.verboseLevel < Develop {
 		return
 	}
 	defer d.flush()

--- a/tools/logger/logger.go
+++ b/tools/logger/logger.go
@@ -1,0 +1,112 @@
+package logger
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (d *Session) Indent() func() *Session {
+	d.AddIndent()
+	return d.RemoveIndent
+}
+
+func (d *Session) Separator() {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	d.messages = append(d.messages, strings.Repeat("=", d.halfBannerLen*2+len(d.sessionID)+2))
+}
+
+func (d *Session) flush() {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	if len(d.messages) == 0 {
+		return
+	}
+	for _, msg := range d.messages {
+		fmt.Println(msg)
+	}
+	d.messages = []string{}
+}
+
+func (d *Session) autoPrint(msg ...interface{}) {
+	switch len(msg) {
+	case 0:
+		return
+	case 1:
+		d.addMessage(fmt.Sprintf("%v", msg[0]))
+	case 2:
+		key, ok := msg[0].(string)
+		if !ok {
+			_, funcName, line, _ := getCallerDetails(2)
+			key = fmt.Sprintf("%s:%d", funcName, line)
+			d.addMapMessage(key, msg)
+		} else {
+			d.addMapMessage(key, msg[1])
+		}
+	default:
+		key, ok := msg[0].(string)
+		if !ok {
+			_, funcName, line, _ := getCallerDetails(2)
+			key = fmt.Sprintf("%s:%d", funcName, line)
+			d.addMapMessage(key, msg)
+		} else {
+			d.addMapMessage(key, msg[1:])
+		}
+	}
+}
+
+// Info logs messages with black color
+func (d *Session) Info(msg ...interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+	d.header = setColor(d.rawHeader, "default")
+	d.autoPrint(msg...)
+}
+
+// Alias for Info
+func (d *Session) Message(msg ...interface{}) {
+	d.Info(msg...)
+}
+
+// Success logs messages with green color
+func (d *Session) Success(msg ...interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+	d.header = setColor(d.rawHeader, "green")
+	d.autoPrint(msg...)
+}
+
+// Warn logs messages with yellow color
+func (d *Session) Warn(msg ...interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+	d.header = setColor(d.rawHeader, "yellow")
+	d.autoPrint(msg...)
+}
+
+// Error logs messages with red color
+func (d *Session) Error(msg ...interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+	d.header = setColor(d.rawHeader, "red")
+	d.autoPrint(msg...)
+}
+
+func (d *Session) Raw(msg ...interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+	d.header = setColor(d.rawHeader, "")
+	d.addRawMessage(msg...)
+}

--- a/tools/logger/processing.go
+++ b/tools/logger/processing.go
@@ -1,0 +1,154 @@
+package logger
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func (d *Session) addRawMessage(m ...interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+	d.messages = append(d.messages,
+		fmt.Sprintf("%s %s%v", d.header, strings.Repeat(d.indentSymbol, d.indentLevel), m))
+}
+
+func (d *Session) addMessage(msg ...interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+	parseMsg := ""
+	for _, m := range msg {
+		parseMsg += fmt.Sprintf(" %v", m)
+	}
+	d.messages = append(d.messages,
+		fmt.Sprintf("%s %s%s", d.header, strings.Repeat(d.indentSymbol, d.indentLevel), parseMsg))
+}
+
+func (d *Session) checkMapOrSlice(value interface{}) (map[string]interface{}, []interface{}, reflect.Value) {
+	v := reflect.ValueOf(value)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return nil, nil, v
+	} else if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	mapVal := make(map[string]interface{})
+	if v.Kind() == reflect.Map {
+		for _, key := range v.MapKeys() {
+			if v.MapIndex(key).IsValid() && v.MapIndex(key).CanInterface() {
+				mapVal[fmt.Sprintf("%v", key)] = v.MapIndex(key).Interface()
+			}
+		}
+	} else if v.Kind() == reflect.Struct {
+		typeOfS := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			if !v.Field(i).IsValid() || !v.Field(i).CanInterface() {
+				continue
+			}
+			val := v.Field(i).Interface()
+			paramName := typeOfS.Field(i).Name
+			mapVal[paramName] = val
+		}
+	}
+
+	if len(mapVal) > 0 {
+		return mapVal, nil, v
+	} else if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		vv := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			vv[i] = v.Index(i).Interface()
+		}
+		return nil, vv, v
+	}
+	return nil, nil, v
+}
+
+func (d *Session) addMapMessage(name string, m interface{}) {
+	if Verbose < d.verboseLevel {
+		return
+	}
+	defer d.flush()
+
+	mapVal, sliceVal, v := d.checkMapOrSlice(m)
+	if mapVal != nil {
+		d.addMessage(name + ": {")
+		d.addInternalMapMessage(mapVal, 0)
+		d.addMessage("}")
+	} else if sliceVal != nil {
+		d.addMessage(name + ": [")
+		d.addInternalSliceMessage(sliceVal, 0)
+		d.addMessage("]")
+	} else {
+		d.addMessage(fmt.Sprintf("%s (kind: %v): %v", name, v.Kind(), v))
+	}
+}
+
+func (d *Session) addInternalMapMessage(m map[string]interface{}, depth int) {
+	defer d.Indent()()
+	if depth > d.maxDepth {
+		d.addMessage("...")
+		return
+	}
+	for k, value := range m {
+		switch value := value.(type) {
+		case map[string]interface{}:
+			d.addMessage(k + ": {")
+			d.addInternalMapMessage(value, depth+1)
+			d.addMessage("}")
+		case []interface{}:
+			d.addMessage(k + ": [")
+			d.addInternalSliceMessage(value, depth+1)
+			d.addMessage("]")
+		default:
+			mapVal, sliceVal, v := d.checkMapOrSlice(value)
+			if mapVal != nil {
+				d.addMessage(k + ": {")
+				d.addInternalMapMessage(mapVal, depth+1)
+				d.addMessage("}")
+			} else if sliceVal != nil {
+				d.addMessage(k + ": [")
+				d.addInternalSliceMessage(sliceVal, depth+1)
+				d.addMessage("]")
+			} else {
+				d.addMessage(fmt.Sprintf("%s (kind: %v): %v", k, v.Kind(), v))
+			}
+		}
+	}
+}
+
+func (d *Session) addInternalSliceMessage(s []interface{}, depth int) {
+	d.indentLevel++
+	defer func() {
+		d.indentLevel--
+	}()
+	if depth > d.maxDepth {
+		d.addMessage("...")
+		return
+	}
+	for _, value := range s {
+		switch value := value.(type) {
+		case map[string]interface{}:
+			d.addMessage("-")
+			d.addInternalMapMessage(value, depth+1)
+		case []interface{}:
+			d.addMessage("-")
+			d.addInternalSliceMessage(value, depth+1)
+		default:
+			mapVal, sliceVal, v := d.checkMapOrSlice(value)
+			if mapVal != nil {
+				d.addMessage("- {")
+				d.addInternalMapMessage(mapVal, depth+1)
+				d.addMessage("}")
+			} else if sliceVal != nil {
+				d.addMessage("- [")
+				d.addInternalSliceMessage(sliceVal, depth+1)
+				d.addMessage("]")
+			} else {
+				d.addMessage(fmt.Sprintf("- (kind: %v): %v", v.Kind(), v))
+			}
+		}
+	}
+}

--- a/tools/logger/processing.go
+++ b/tools/logger/processing.go
@@ -10,7 +10,6 @@ func (d *Session) addRawMessage(m ...interface{}) {
 	if Verbose < d.verboseLevel {
 		return
 	}
-	defer d.flush()
 	d.messages = append(d.messages,
 		fmt.Sprintf("%s %s%v", d.header, strings.Repeat(d.indentSymbol, d.indentLevel), m))
 }
@@ -19,7 +18,6 @@ func (d *Session) addMessage(msg ...interface{}) {
 	if Verbose < d.verboseLevel {
 		return
 	}
-	defer d.flush()
 	parseMsg := ""
 	for _, m := range msg {
 		parseMsg += fmt.Sprintf(" %v", m)
@@ -70,8 +68,6 @@ func (d *Session) addMapMessage(name string, m interface{}) {
 	if Verbose < d.verboseLevel {
 		return
 	}
-	defer d.flush()
-
 	mapVal, sliceVal, v := d.checkMapOrSlice(m)
 	if mapVal != nil {
 		d.addMessage(name + ": {")
@@ -120,10 +116,7 @@ func (d *Session) addInternalMapMessage(m map[string]interface{}, depth int) {
 }
 
 func (d *Session) addInternalSliceMessage(s []interface{}, depth int) {
-	d.indentLevel++
-	defer func() {
-		d.indentLevel--
-	}()
+	defer d.Indent()()
 	if depth > d.maxDepth {
 		d.addMessage("...")
 		return

--- a/tools/logger/processing.go
+++ b/tools/logger/processing.go
@@ -7,17 +7,11 @@ import (
 )
 
 func (d *Session) addRawMessage(m ...interface{}) {
-	if Verbose < d.verboseLevel {
-		return
-	}
 	d.messages = append(d.messages,
 		fmt.Sprintf("%s %s%v", d.header, strings.Repeat(d.indentSymbol, d.indentLevel), m))
 }
 
 func (d *Session) addMessage(msg ...interface{}) {
-	if Verbose < d.verboseLevel {
-		return
-	}
 	parseMsg := ""
 	for _, m := range msg {
 		parseMsg += fmt.Sprintf(" %v", m)
@@ -65,9 +59,6 @@ func (d *Session) checkMapOrSlice(value interface{}) (map[string]interface{}, []
 }
 
 func (d *Session) addMapMessage(name string, m interface{}) {
-	if Verbose < d.verboseLevel {
-		return
-	}
 	mapVal, sliceVal, v := d.checkMapOrSlice(m)
 	if mapVal != nil {
 		d.addMessage(name + ": {")

--- a/tools/logger/readme.md
+++ b/tools/logger/readme.md
@@ -1,0 +1,72 @@
+# Logger
+
+## Description
+
+This tool is used to log messages to the console for a better debugging experience.
+
+## Features
+ - Automatically expand objects and arrays to make it easier to read.
+ - Provide a clear interface to log messages in colors.
+ - While no name is provided, the tool will utilize the file name, the function name and the line of file as logger information.
+
+## Usage
+
+1. Import the package
+   ```golang
+    import 	"github.com/instill-ai/component/tools/logger"
+   ```
+2. Create a new logger session
+   ```golang
+   logger := logger.SessionStart("Logger Name", VerboseLevel)
+   defer logger.SessionEnd()
+   ```
+    - The first parameter is the name of the logger. If an empty name is provided, the logger will use the file name and the function name as session id.
+    - The second parameter is the verbose level of the logger. The logger will only log messages with the level equal to or lower than the verbose level. The verbose level is an integer, and the logger provides the following levels:
+        - Static : No message will be logged
+        - Error  : Only error messages will be logged
+        - Warn   : Error and warning messages will be logged
+        - Develop: All messages will be logged
+3. Use the logger to log messages
+    - Single message
+    ```golang
+    logger.Info("This is an info message")
+    logger.Warn("This is a warning message")
+    logger.Success("This is a success message")
+    logger.Error("This is an error message")
+    ```
+    - Messages with a title (if the first parameter is type of string)
+    ```golang
+    logger.Info("Title 1", "This is an info message")
+    logger.Info("Title 2", structA, structB, structC)
+    // Output:
+    // - Title 1: This is an info message
+    // - Title 2: [
+    //   structA {
+    //     ...
+    //   },
+    //   structB {
+    //     ...
+    //   },
+    //   ...
+    // ]
+    ...
+    ```
+    - Message with only non-string data
+    ```golang
+    logger.Info(structA, structB, structC)
+    // Output:
+    // - functionName:lineNumber : [
+    //   structA {
+    //     ...
+    //   },
+    //   structB {
+    //     ...
+    //   },
+    //   ...
+    // ]
+    ...
+    ```
+
+## Note
+- The default expand level is 5. If you want to expand more or less, you can change the value by calling the function `logger.SetMaxDepth(level int)`.
+- The default indent symbol is "  " (2 spaces) . You can change the indent symbol by calling the function `logger.SetIndentSymbol(symbol string)`.

--- a/tools/logger/readme.md
+++ b/tools/logger/readme.md
@@ -49,7 +49,6 @@ This tool is used to log messages to the console for a better debugging experien
     //   },
     //   ...
     // ]
-    ...
     ```
     - Message with only non-string data
     ```golang
@@ -64,7 +63,6 @@ This tool is used to log messages to the console for a better debugging experien
     //   },
     //   ...
     // ]
-    ...
     ```
 
 ## Note

--- a/tools/logger/setting.go
+++ b/tools/logger/setting.go
@@ -7,10 +7,12 @@ import (
 	"github.com/fatih/color"
 )
 
+// Verbose Level for the logger to determine whether to print the log or not
 const (
-	Verbose             = 1
-	DevelopVerboseLevel = 1
-	StaticVerboseLevel  = 2
+	Static  = iota // Sessions set to this level will never print
+	Error          // Sessions set to this level will only print errors
+	Warn           // Sessions set to this level will print errors and warnings
+	Develop        // Developing sessions will print all logs
 )
 
 type Session struct {
@@ -32,7 +34,7 @@ type Session struct {
 // If no name is provided, the name will be <filename>:<function name> of the caller
 func (d *Session) SessionStart(name string, verboseLevel int) (self *Session) {
 	d.verboseLevel = verboseLevel
-	if Verbose < verboseLevel {
+	if verboseLevel < Static {
 		return d
 	}
 	defer d.flush()
@@ -50,7 +52,7 @@ func (d *Session) SessionStart(name string, verboseLevel int) (self *Session) {
 	/************ Set Default Value ************/
 	d.halfBannerLen = 20
 	d.indentLevel = 0
-	d.maxDepth = 5 * Verbose
+	d.maxDepth = 5
 	d.active = true
 	d.messages = []string{}
 	d.indentSymbol = "  "
@@ -67,7 +69,7 @@ func (d *Session) SessionStart(name string, verboseLevel int) (self *Session) {
 }
 
 func (d *Session) SessionEnd() (self *Session) {
-	if Verbose < d.verboseLevel || !d.active {
+	if d.verboseLevel < Static || !d.active {
 		return d
 	}
 	defer d.flush()

--- a/tools/logger/setting.go
+++ b/tools/logger/setting.go
@@ -1,0 +1,99 @@
+package logger
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+const (
+	Verbose             = 1
+	DevelopVerboseLevel = 1
+	StaticVerboseLevel  = 2
+)
+
+type Session struct {
+	sessionID     string
+	title         string
+	messages      []string
+	active        bool
+	halfBannerLen int
+	indentLevel   int
+	maxDepth      int
+	verboseLevel  int
+	rawHeader     string
+	header        string
+	indentSymbol  string
+}
+
+// Session Logger is only verbose when package verbose is greater than the verbose level specified here
+func (d *Session) SessionStart(name string, verboseLevel int) (self *Session) {
+	d.verboseLevel = verboseLevel
+	if Verbose < verboseLevel {
+		return d
+	}
+	defer d.flush()
+	if d.active {
+		d.SessionEnd()
+	}
+
+	if name == "" {
+		name = "Unknown"
+		sanitizedFilename, sanitizedFuncName, _, ok := getCallerDetails(1)
+		if ok {
+			name = fmt.Sprintf("%s:%s", sanitizedFilename, sanitizedFuncName)
+		}
+	}
+	/************ Set Default Value ************/
+	d.halfBannerLen = 20
+	d.indentLevel = 0
+	d.maxDepth = 5 * Verbose
+	d.active = true
+	d.messages = []string{}
+	d.indentSymbol = "  "
+	/*******************************************/
+
+	halfBanner := strings.Repeat("=", d.halfBannerLen)
+	d.sessionID = name
+
+	d.rawHeader = fmt.Sprintf("[%s]", name)
+	d.header = color.BlackString(d.rawHeader)
+	d.title = fmt.Sprintf("%s %s %s", halfBanner, name, halfBanner)
+	d.messages = append(d.messages, d.title)
+	return d
+}
+
+func (d *Session) SessionEnd() (self *Session) {
+	if Verbose < d.verboseLevel || !d.active {
+		return d
+	}
+	defer d.flush()
+	defer func() {
+		d.indentLevel = 0
+		d.active = false
+	}()
+	endHalfBanner := strings.Repeat("=", d.halfBannerLen-2)
+	endBanner := fmt.Sprintf("%s %s end %s", endHalfBanner, d.sessionID, endHalfBanner)
+	d.messages = append(d.messages, endBanner)
+	return d
+}
+
+func (d *Session) AddIndent() (self *Session) {
+	d.indentLevel++
+	return d
+}
+func (d *Session) RemoveIndent() (self *Session) {
+	d.indentLevel--
+	return d
+}
+
+func (d *Session) SetMaxDepth(depth int) (self *Session) {
+	d.maxDepth = depth
+	return d
+}
+
+func (d *Session) SetIndentSymbol(symbol string) (self *Session) {
+	d.indentSymbol = symbol
+	return d
+}

--- a/tools/logger/setting.go
+++ b/tools/logger/setting.go
@@ -27,7 +27,9 @@ type Session struct {
 	indentSymbol  string
 }
 
-// Session Logger is only verbose when package verbose is greater than the verbose level specified here
+// Session Logger is only verbose when package verbose is greater than the verbose level specified here.
+//
+// If no name is provided, the name will be <filename>:<function name> of the caller
 func (d *Session) SessionStart(name string, verboseLevel int) (self *Session) {
 	d.verboseLevel = verboseLevel
 	if Verbose < verboseLevel {
@@ -79,11 +81,11 @@ func (d *Session) SessionEnd() (self *Session) {
 	return d
 }
 
-func (d *Session) AddIndent() (self *Session) {
+func (d *Session) IncrementIndent() (self *Session) {
 	d.indentLevel++
 	return d
 }
-func (d *Session) RemoveIndent() (self *Session) {
+func (d *Session) DecrementIndent() (self *Session) {
 	d.indentLevel--
 	return d
 }

--- a/tools/logger/utils.go
+++ b/tools/logger/utils.go
@@ -1,0 +1,53 @@
+package logger
+
+import (
+	"runtime"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+func sanitizeName(name string) string {
+	funcNameList := strings.Split(name, "/")
+	return funcNameList[len(funcNameList)-1]
+}
+
+// The argument skip is the number of stack frames to ascend, with 0 identifying the caller of Caller.
+func getCallerDetails(skip int) (filename string, funcName string, line int, ok bool) {
+	pc, filename, line, ok := runtime.Caller(skip + 1)
+	if !ok {
+		return "", "", 0, false
+	}
+
+	sanitizedFuncName := sanitizeName(runtime.FuncForPC(pc).Name())
+	if strings.Contains(sanitizedFuncName, ".") {
+		funcNameList := strings.Split(sanitizedFuncName, ".")
+		sanitizedFuncName = funcNameList[len(funcNameList)-1]
+	}
+	sanitizedFilename := sanitizeName(filename)
+	return sanitizedFilename, sanitizedFuncName, line, true
+}
+
+func setColor(text string, c string) (coloredText string) {
+	switch c {
+	case "red":
+		coloredText = color.RedString(text)
+	case "green":
+		coloredText = color.GreenString(text)
+	case "yellow":
+		coloredText = color.YellowString(text)
+	case "blue":
+		coloredText = color.BlueString(text)
+	case "magenta":
+		coloredText = color.MagentaString(text)
+	case "cyan":
+		coloredText = color.CyanString(text)
+	case "white":
+		coloredText = color.WhiteString(text)
+	case "black":
+		coloredText = color.BlackString(text)
+	default:
+		coloredText = text
+	}
+	return
+}


### PR DESCRIPTION
Because

- We need a simple interface to log structs and maps prettily.
- Current jsonl logger format is difficult to read while developing

This commit

- Implement a logger that can auto-adjust to and expand any type of object
