### PR TITLE
feat: introduce event handler interface

### DIFF
--- a/application/github/v0/main.go
+++ b/application/github/v0/main.go
@@ -113,3 +113,15 @@ func (e *execution) Execute(ctx context.Context, inputs []*structpb.Struct) ([]*
 
 	return outputs, nil
 }
+
+func (c *component) HandleVerificationEvent(header map[string][]string, req *structpb.Struct, setup map[string]any) (isVerification bool, resp *structpb.Struct, err error) {
+	if len(header["x-github-event"]) > 0 && header["x-github-event"][0] == "ping" {
+		return true, nil, nil
+	}
+	return false, nil, nil
+}
+
+func (c *component) ParseEvent(ctx context.Context, req *structpb.Struct, setup map[string]any) (parsed *structpb.Struct, err error) {
+	// TODO: parse and validate event
+	return req, nil
+}

--- a/application/slack/v0/main.go
+++ b/application/slack/v0/main.go
@@ -103,3 +103,23 @@ func (c *component) Test(sysVars map[string]any, setup *structpb.Struct) error {
 
 	return nil
 }
+
+func (c *component) HandleVerificationEvent(header map[string][]string, req *structpb.Struct, setup map[string]any) (isVerification bool, resp *structpb.Struct, err error) {
+
+	switch event := req.GetFields()["type"].GetStringValue(); event {
+	case "url_verification":
+		resp, _ := structpb.NewStruct(map[string]any{
+			"challenge": req.GetFields()["challenge"].GetStringValue(),
+		})
+		return true, resp, nil
+	default:
+		return false, nil, nil
+
+	}
+
+}
+
+func (c *component) ParseEvent(ctx context.Context, req *structpb.Struct, setup map[string]any) (parsed *structpb.Struct, err error) {
+	// TODO: parse and validate event
+	return req, nil
+}

--- a/base/component.go
+++ b/base/component.go
@@ -1,12 +1,12 @@
 package base
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/gofrs/uuid"
-
 	"github.com/lestrrat-go/jsref/provider"
 	"go.uber.org/zap"
 	"golang.org/x/text/cases"
@@ -83,6 +83,11 @@ type IComponent interface {
 
 	IsSecretField(target string) bool
 
+	// Note: These two functions are for the pipeline run-on-event feature,
+	// which is still experimental and may change at any time.
+	HandleVerificationEvent(header map[string][]string, req *structpb.Struct, setup map[string]any) (isVerification bool, resp *structpb.Struct, err error)
+	ParseEvent(ctx context.Context, req *structpb.Struct, setup map[string]any) (parsed *structpb.Struct, err error)
+
 	UsageHandlerCreator() UsageHandlerCreator
 }
 
@@ -96,6 +101,14 @@ type Component struct {
 
 	definition   *pb.ComponentDefinition
 	secretFields []string
+}
+
+func (c *Component) HandleVerificationEvent(header map[string][]string, req *structpb.Struct, setup map[string]any) (isVerification bool, resp *structpb.Struct, err error) {
+	return false, nil, nil
+}
+
+func (c *Component) ParseEvent(ctx context.Context, req *structpb.Struct, setup map[string]any) (parsed *structpb.Struct, err error) {
+	return req, nil
 }
 
 func convertDataSpecToCompSpec(dataSpec *structpb.Struct) (*structpb.Struct, error) {

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/h2non/filetype v1.1.3
 	github.com/iFaceless/godub v0.0.0-20200728093528-a30bb4d1a0f1
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240729181905-96683859f44c
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/itchyny/gojq v0.12.14
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/iFaceless/godub v0.0.0-20200728093528-a30bb4d1a0f1 h1:oqeURuHQrImMykykqJgFbStlaDXyY7JpXXrwXyjr9ls=
 github.com/iFaceless/godub v0.0.0-20200728093528-a30bb4d1a0f1/go.mod h1:tKRg0K9YmfD3eD6KFos+YHIVMouKMzxDSK5XpdxdCUI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d h1:g+myl44XmerPUONSkXKdnZ2PSBCixqSCqah0dQtBkeI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240729181905-96683859f44c h1:brSsYUlzMl4Oluis2z8NTyJvwTSBosn5u97BHG1ms7k=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240729181905-96683859f44c/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=
 github.com/instill-ai/x v0.4.0-alpha/go.mod h1:L6jmDPrUou6XskaLXZuK/gDeitdoPa9yE8ONKt1ZwCw=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=

--- a/store/store.go
+++ b/store/store.go
@@ -164,6 +164,13 @@ func (s *Store) CreateExecution(defUID uuid.UUID, sysVars map[string]any, setup 
 	return nil, fmt.Errorf("component definition not found")
 }
 
+func (s *Store) HandleVerificationEvent(defID string, header map[string][]string, req *structpb.Struct, setup map[string]any) (bool, *structpb.Struct, error) {
+	if c, ok := s.componentIDMap[defID]; ok {
+		return c.comp.HandleVerificationEvent(header, req, setup)
+	}
+	return false, nil, fmt.Errorf("component definition not found")
+}
+
 // GetDefinitionByUID returns a component definition by its UID.
 func (s *Store) GetDefinitionByUID(defUID uuid.UUID, sysVars map[string]any, compConfig *base.ComponentConfig) (*pb.ComponentDefinition, error) {
 	if c, ok := s.componentUIDMap[defUID]; ok {


### PR DESCRIPTION
Because

- We are introducing the run-on-event feature, which allows users to configure webhook event handlers for each vendor.

This commit

- Introduces an event handler interface to: 
  1. Handle verification/ping events.
  2. Handle data events.

Note

- This is still an experimental feature and may change at any time.