### PR TITLE
chore(instill): use VIEW_BASIC when sending request to Instill Model

### DIFF
--- a/ai/instill/v0/main.go
+++ b/ai/instill/v0/main.go
@@ -197,7 +197,7 @@ func (c *component) GetDefinition(sysVars map[string]any, compConfig *base.Compo
 	pageSize := int32(100)
 	modelNameMap := map[string]*structpb.ListValue{}
 	for {
-		resp, err := gRPCCLient.ListModels(ctx, &modelPB.ListModelsRequest{PageToken: &pageToken, PageSize: &pageSize, View: modelPB.View_VIEW_FULL.Enum()})
+		resp, err := gRPCCLient.ListModels(ctx, &modelPB.ListModelsRequest{PageToken: &pageToken, PageSize: &pageSize, View: modelPB.View_VIEW_BASIC.Enum()})
 		if err != nil {
 			return def, nil
 		}


### PR DESCRIPTION
Because

- We don't need `VIEW_FULL` for retrieving the entire model definition.

This commit

- Uses `VIEW_BASIC` when sending requests to Instill Model.