### PR TITLE
fix: bug of json without setting array for images

### DIFF
--- a/operator/video/v0/config/tasks.json
+++ b/operator/video/v0/config/tasks.json
@@ -162,7 +162,7 @@
       "properties": {
         "frames": {
           "description": "Base64 encoded sub-sampled frames",
-          "instillFormat": "image/*",
+          "instillFormat": "array:image/*",
           "instillUIOrder": 0,
           "items": {
             "type": "string",


### PR DESCRIPTION
Because

- the response is array but no array in schema

This commit

- fix schema bug
