### PR TITLE
chore(video): fix video codec

### DIFF
--- a/operator/audio/v0/config/tasks.json
+++ b/operator/audio/v0/config/tasks.json
@@ -12,7 +12,8 @@
         "audio": {
           "description": "Base64 encoded audio file to be split",
           "instillAcceptFormats": [
-            "audio/*"
+            "audio/*",
+            "application/octet-stream"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -79,7 +80,8 @@
         "audio": {
           "description": "Base64 encoded audio file to be sliced",
           "instillAcceptFormats": [
-            "audio/*"
+            "audio/*",
+            "application/octet-stream"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [

--- a/operator/video/v0/config/tasks.json
+++ b/operator/video/v0/config/tasks.json
@@ -12,7 +12,8 @@
         "video": {
           "description": "Base64 encoded video",
           "instillAcceptFormats": [
-            "video/*"
+            "video/*",
+            "application/octet-stream"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -100,7 +101,8 @@
         "video": {
           "description": "Base64 encoded video",
           "instillAcceptFormats": [
-            "video/*"
+            "video/*",
+            "application/octet-stream"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [

--- a/operator/video/v0/video_operation.go
+++ b/operator/video/v0/video_operation.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/instill-ai/component/base"
@@ -59,8 +58,6 @@ func subsampleVideo(input *structpb.Struct) (*structpb.Struct, error) {
 		return nil, fmt.Errorf("error in decoding for inner: %s", err)
 	}
 
-	videoPrefix := strings.Split(base64Video, ",")[0]
-
 	// TODO: chuang8511 map the file extension to the correct format
 	tempInputFile, err := os.CreateTemp("", "temp.*.mp4")
 
@@ -92,7 +89,7 @@ func subsampleVideo(input *structpb.Struct) (*structpb.Struct, error) {
 	}
 
 	byOut, _ := os.ReadFile(tempOutputFileName)
-	base64Subsample := videoPrefix + "," + base64.StdEncoding.EncodeToString(byOut)
+	base64Subsample := "data:video/mp4;base64," + base64.StdEncoding.EncodeToString(byOut)
 
 	output := SubsampleVideoOutput{
 		Video: Video(base64Subsample),
@@ -109,6 +106,10 @@ func getKwArgs(inputStruct SubsampleVideoInput) ffmpeg.KwArgs {
 	if inputStruct.Duration != "" {
 		kwArgs["t"] = inputStruct.Duration
 	}
+	// Set yuv420p to ensure video compatibility across various operating
+	// systems video viewer.
+	kwArgs["pix_fmt"] = "yuv420p"
+
 	return kwArgs
 }
 


### PR DESCRIPTION
Because

- The codec wasn't displaying correctly on Console.

This commit

- Fixes the video codec by setting the MIME header to mp4 and the format to `yuv420p`, making it viewable on most players.