### PR TITLE
chore(googlesearch): fix syntax

### DIFF
--- a/application/googlesearch/v0/README.mdx
+++ b/application/googlesearch/v0/README.mdx
@@ -31,7 +31,7 @@ The component configuration is defined and maintained [here](https://github.com/
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | API Key for the Google Custom Search API. You can create one <a href="https://developers.google.com/custom-search/v1/overview#api-key">here</a> |
-| Search Engine ID (required) | `cse-id` | string | ID of the Search Engine to use. Before using the Custom Search JSON API you will first need to create and configure your Programmable Search Engine. If you have not already created a Programmable Search Engine, you can start by visiting <a href="https://programmablesearchengine.google.com/controlpanel/all">the Programmable Search Engine control panel</a>. <br> You can find this in the URL of your Search Engine. For example, if the URL of your search engine is https://cse.google.com/cse.js?cx=012345678910, the ID value is: 012345678910 |
+| Search Engine ID (required) | `cse-id` | string | ID of the Search Engine to use. Before using the Custom Search JSON API you will first need to create and configure your Programmable Search Engine. If you have not already created a Programmable Search Engine, you can start by visiting [the Programmable Search Engine control panel](https://programmablesearchengine.google.com/controlpanel/all). <br /> You can find this in the URL of your Search Engine. For example, if the URL of your search engine is `https://cse.google.com/cse.js?cx=012345678910`, the ID value is: `012345678910` |
 
 
 

--- a/application/googlesearch/v0/config/setup.json
+++ b/application/googlesearch/v0/config/setup.json
@@ -13,7 +13,7 @@
       "type": "string"
     },
     "cse-id": {
-      "description": "ID of the Search Engine to use. Before using the Custom Search JSON API you will first need to create and configure your Programmable Search Engine. If you have not already created a Programmable Search Engine, you can start by visiting <a href=\"https://programmablesearchengine.google.com/controlpanel/all\">the Programmable Search Engine control panel</a>. <br> You can find this in the URL of your Search Engine. For example, if the URL of your search engine is https://cse.google.com/cse.js?cx=012345678910, the ID value is: 012345678910",
+      "description": "ID of the Search Engine to use. Before using the Custom Search JSON API you will first need to create and configure your Programmable Search Engine. If you have not already created a Programmable Search Engine, you can start by visiting [the Programmable Search Engine control panel](https://programmablesearchengine.google.com/controlpanel/all). <br /> You can find this in the URL of your Search Engine. For example, if the URL of your search engine is `https://cse.google.com/cse.js?cx=012345678910`, the ID value is: `012345678910`",
       "instillUpstreamTypes": [
         "value"
       ],


### PR DESCRIPTION
Because

- there is typo in doc

This commit

- fix the typo
