### PR TITLE
chore(ollama): add documentation to self hosting ollama instance

### DIFF
--- a/ai/ollama/v0/.compogen/setup-hosting.mdx
+++ b/ai/ollama/v0/.compogen/setup-hosting.mdx
@@ -1,0 +1,13 @@
+#### Local Ollama Instance
+
+To set up an Ollama instance on your local machine, follow the instructions below:
+
+> Note: These instructions only work for Instill Core CE
+
+1. Follow the tutorial on the official [GitHub repository](https://github.com/ollama/ollama) to install Ollama on your machine.
+2. Follow the instructions in the [FAQ section](https://github.com/ollama/ollama/blob/main/docs/faq.md) to modify the variable `OLLAMA_HOST` to `0.0.0.0`, then restart Ollama.
+3. Get the IP address of your machine on the local network.
+    - On Linux and macOS, open the terminal and type `ifconfig`.
+    - On Windows, open the command prompt and type `ipconfig`.
+4. Suppose the IP address is `192.168.178.88`, then the Ollama hosting endpoint would be `192.168.178.88:11434`.
+5. Enjoy fast LLM inference on your local machine with VDP's capability.

--- a/ai/ollama/v0/.compogen/setup-hosting.mdx
+++ b/ai/ollama/v0/.compogen/setup-hosting.mdx
@@ -10,4 +10,4 @@ To set up an Ollama instance on your local machine, follow the instructions belo
     - On Linux and macOS, open the terminal and type `ifconfig`.
     - On Windows, open the command prompt and type `ipconfig`.
 4. Suppose the IP address is `192.168.178.88`, then the Ollama hosting endpoint would be `192.168.178.88:11434`.
-5. Enjoy fast LLM inference on your local machine with VDP's capability.
+5. Enjoy fast LLM inference on your local machine and integration with 💧 Instill VDP.

--- a/ai/ollama/v0/README.mdx
+++ b/ai/ollama/v0/README.mdx
@@ -64,7 +64,19 @@ Provide text outputs in response to text/image inputs.
 | Text | `text` | string | Model Output |
 
 
+#### Local Ollama Instance
 
+To set up an Ollama instance on your local machine, follow the instructions below:
+
+> Note: These instructions only work for Instill Core CE
+
+1. Follow the tutorial on the official [GitHub repository](https://github.com/ollama/ollama) to install Ollama on your machine.
+2. Follow the instructions in the [FAQ section](https://github.com/ollama/ollama/blob/main/docs/faq.md) to modify the variable `OLLAMA_HOST` to `0.0.0.0`, then restart Ollama.
+3. Get the IP address of your machine on the local network.
+    - On Linux and macOS, open the terminal and type `ifconfig`.
+    - On Windows, open the command prompt and type `ipconfig`.
+4. Suppose the IP address is `192.168.178.88`, then the Ollama hosting endpoint would be `192.168.178.88:11434`.
+5. Enjoy fast LLM inference on your local machine with VDP's capability.
 
 
 

--- a/ai/ollama/v0/README.mdx
+++ b/ai/ollama/v0/README.mdx
@@ -68,7 +68,9 @@ Provide text outputs in response to text/image inputs.
 
 To set up an Ollama instance on your local machine, follow the instructions below:
 
-> Note: These instructions only work for Instill Core CE
+<InfoBlock type="info" title="info"> 
+  Please note that these instructions will only work for self-hosted **🔮 Instill Core**.
+</InfoBlock>
 
 1. Follow the tutorial on the official [GitHub repository](https://github.com/ollama/ollama) to install Ollama on your machine.
 2. Follow the instructions in the [FAQ section](https://github.com/ollama/ollama/blob/main/docs/faq.md) to modify the variable `OLLAMA_HOST` to `0.0.0.0`, then restart Ollama.

--- a/ai/ollama/v0/main.go
+++ b/ai/ollama/v0/main.go
@@ -1,4 +1,4 @@
-//go:generate compogen readme ./config ./README.mdx
+//go:generate compogen readme ./config ./README.mdx --extraContents TASK_TEXT_GENERATION_CHAT=.compogen/setup-hosting.mdx
 package ollama
 
 import (


### PR DESCRIPTION
Because

- We want to help users setup ollama instance and connect it to VDP.

This commit

- Add documentation with:
    - Install ollama
    - Expose ollama to local network
    - Connect ollama server to ollama client on VDP
