### PR TITLE
feat(document): integrate pdf2md in document operator

### DIFF
--- a/operator/document/v0/README.mdx
+++ b/operator/document/v0/README.mdx
@@ -38,7 +38,6 @@ Convert document to text in Markdown format.
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CONVERT_TO_MARKDOWN` |
 | Document (required) | `document` | string | Base64 encoded PDF/DOCX/DOC/PPTX/PPT/HTML to be converted to text in Markdown format |
-| Display image tag | `display-image-tag` | boolean | Choose if the result displays image tags |
 
 
 

--- a/operator/document/v0/config/tasks.json
+++ b/operator/document/v0/config/tasks.json
@@ -20,20 +20,6 @@
           ],
           "title": "Document",
           "type": "string"
-        },
-        "display-image-tag": {
-          "description": "Choose if the result displays image tags",
-          "instillAcceptFormats": [
-            "boolean"
-          ],
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "instillUIOrder": 1,
-          "title": "Display image tag",
-          "type": "boolean"
         }
       },
       "required": [

--- a/operator/document/v0/convert_document_to_markdown.go
+++ b/operator/document/v0/convert_document_to_markdown.go
@@ -11,6 +11,7 @@ import (
 type convertDocumentToMarkdownInput struct {
 	Document        string `json:"document"`
 	DisplayImageTag bool   `json:"display-image-tag"`
+	Converter       string `json:"converter"`
 }
 
 type convertDocumentToMarkdownOutput struct {
@@ -64,24 +65,28 @@ func getMarkdownTransformer(fileExtension string, inputStruct convertDocumentToM
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
 			DisplayImageTag:   inputStruct.DisplayImageTag,
+			Converter:         inputStruct.Converter,
 		}, nil
 	case "doc", "docx":
 		return DocxDocToMarkdownTransformer{
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
 			DisplayImageTag:   inputStruct.DisplayImageTag,
+			Converter:         inputStruct.Converter,
 		}, nil
 	case "ppt", "pptx":
 		return PptPptxToMarkdownTransformer{
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
 			DisplayImageTag:   inputStruct.DisplayImageTag,
+			Converter:         inputStruct.Converter,
 		}, nil
 	case "html":
 		return HTMLToMarkdownTransformer{
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
 			DisplayImageTag:   inputStruct.DisplayImageTag,
+			Converter:         inputStruct.Converter,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported file type")

--- a/operator/document/v0/convert_document_to_markdown_test.go
+++ b/operator/document/v0/convert_document_to_markdown_test.go
@@ -44,6 +44,7 @@ func TestConvertDocumentToMarkdown(t *testing.T) {
 			inputStruct := convertDocumentToMarkdownInput{
 				Document:        base64DataURI,
 				DisplayImageTag: false,
+				Converter:       "instill",
 			}
 			input, err := base.ConvertToStructpb(inputStruct)
 			c.Assert(err, quicktest.IsNil)
@@ -88,6 +89,7 @@ type FakeMarkdownTransformer struct {
 	Base64EncodedText string
 	FileExtension     string
 	DisplayImageTag   bool
+	Converter         string
 }
 
 func (f FakeMarkdownTransformer) Transform() (string, error) {


### PR DESCRIPTION
Because

- The original PDF-to-Markdown algorithm is not robust.

This commit

- Integrates `pdf2md` into the document operator.