### PR TITLE
chore(numbers): support x-api-key header

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -151,7 +151,13 @@ func Init(
 			compStore.Import(conn)
 		}
 
-		compStore.Import(numbers.Init(baseComp))
+		{
+			// Numbers
+			conn := numbers.Init(baseComp)
+			conn = conn.WithNumbersSecret(secrets[conn.GetDefinitionID()])
+			compStore.Import(conn)
+		}
+
 		compStore.Import(bigquery.Init(baseComp))
 		compStore.Import(googlecloudstorage.Init(baseComp))
 		compStore.Import(googlesearch.Init(baseComp))


### PR DESCRIPTION
Because

- Numbers Protocol has introduced a new header `x-api-key` for identification.

This commit

- Supports `x-api-key` header.
