### PR TITLE
fix(artifact): add the description to remind users to add file extension

### DIFF
--- a/data/artifact/v0/config/tasks.json
+++ b/data/artifact/v0/config/tasks.json
@@ -167,7 +167,7 @@
                   "$ref": "#/$defs/file"
                 },
                 "file-name": {
-                  "description": "The name of the file",
+                  "description": "The name of the file, please remember to add the file extension in the end of file name. e.g. 'example.pdf'",
                   "instillUIOrder": 2,
                   "instillAcceptFormats": [
                     "string"
@@ -223,7 +223,7 @@
                   "$ref": "#/$defs/file"
                 },
                 "file-name": {
-                  "description": "The name of the file",
+                  "description": "The name of the file, please remember to add the file extension in the end of file name. e.g. 'example.pdf'",
                   "instillUIOrder": 3,
                   "instillAcceptFormats": [
                     "string"


### PR DESCRIPTION
Because

- the file name should include file extension as suffix

This commit

- add description for users
