### PR TITLE
fix(artifact): log the error that should not raise

### DIFF
--- a/data/artifact/v0/artifact_operation.go
+++ b/data/artifact/v0/artifact_operation.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -77,7 +78,11 @@ func (e *execution) uploadFiles(input *structpb.Struct) (*structpb.Struct, error
 		})
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to create new catalog: %w", err)
+			if strings.Contains(err.Error(), "knowledge base name already exists") {
+				log.Println("Catalog already exists, skipping creation")
+			} else {
+				return nil, fmt.Errorf("failed to create new catalog: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Because

- we do not have to raise error when the users plan to upload a file to a catalog

This commit

- log error but not raise error
