### PR TITLE
fix(document): catch the error if there is no data in sheet

### DIFF
--- a/operator/document/v0/markdown_transformer.go
+++ b/operator/document/v0/markdown_transformer.go
@@ -172,6 +172,12 @@ func (t XlsxToMarkdownTransformer) Transform() (string, error) {
 			return "", fmt.Errorf("failed to get rows: %w", err)
 		}
 
+		if len(rows) == 0 {
+			result += fmt.Sprintf("# %s\n", sheet)
+			result += "No data found\n\n"
+			continue
+		}
+
 		result += fmt.Sprintf("# %s\n", sheet)
 		result += util.ConvertDataFrameToMarkdownTable(rows)
 		result += "\n\n"


### PR DESCRIPTION
Because

- we cannot read pivot table with the current package

This commit

- catch the error if there is no data in sheet
