### PR TITLE
feat: use error type for component definition not found error

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -215,7 +215,7 @@ type ExecutionParams struct {
 func (s *Store) CreateExecution(p ExecutionParams) (*base.ExecutionWrapper, error) {
 	c, ok := s.componentIDMap[p.ComponentDefinitionID]
 	if !ok {
-		return nil, fmt.Errorf("component definition not found")
+		return nil, ErrComponentDefinitionNotFound
 	}
 
 	x, err := c.comp.CreateExecution(base.ComponentExecution{
@@ -248,7 +248,7 @@ func (s *Store) GetDefinitionByUID(defUID uuid.UUID, sysVars map[string]any, com
 		}
 		return proto.Clone(def).(*pb.ComponentDefinition), err
 	}
-	return nil, fmt.Errorf("component definition not found")
+	return nil, ErrComponentDefinitionNotFound
 }
 
 // GetDefinitionByID returns a component definition by its ID.
@@ -260,7 +260,7 @@ func (s *Store) GetDefinitionByID(defID string, sysVars map[string]any, compConf
 		}
 		return proto.Clone(def).(*pb.ComponentDefinition), err
 	}
-	return nil, fmt.Errorf("component definition not found")
+	return nil, ErrComponentDefinitionNotFound
 }
 
 // ListDefinitions returns all the loaded component definitions.
@@ -282,5 +282,9 @@ func (s *Store) IsSecretField(defUID uuid.UUID, target string) (bool, error) {
 	if c, ok := s.componentUIDMap[defUID]; ok {
 		return c.comp.IsSecretField(target), nil
 	}
-	return false, fmt.Errorf("component definition not found")
+	return false, ErrComponentDefinitionNotFound
 }
+
+// ErrComponentDefinitionNotFound is returned when trying to access an
+// inexistent component definition.
+var ErrComponentDefinitionNotFound = fmt.Errorf("component definition not found")


### PR DESCRIPTION
Because

- Clients (i.e. `pipeline-backend`) need to discern not found errors from other
  errors when fetching a component definition.

This commit

- Returns an error type instead of just a message so clients can perform a check
  to detect the not found scenario.
