### PR TITLE
refactor: encapsulate operations in InputReader and OutputWriter

### DIFF
--- a/base/execution_wrapper.go
+++ b/base/execution_wrapper.go
@@ -14,30 +14,52 @@ type ExecutionWrapper struct {
 	IExecution
 }
 
+type inputReaderInterceptor struct {
+	InputReader
+	schema       string
+	usageHandler UsageHandler
+	inputs       []*structpb.Struct
+}
+
+func (ir *inputReaderInterceptor) Read(ctx context.Context) (inputs []*structpb.Struct, err error) {
+	inputs, err = ir.InputReader.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err = Validate(inputs, ir.schema, "inputs"); err != nil {
+		return nil, err
+	}
+
+	if err = ir.usageHandler.Check(ctx, inputs); err != nil {
+		return nil, err
+	}
+	ir.inputs = inputs
+	return inputs, nil
+}
+
 type outputWriterInterceptor struct {
 	OutputWriter
-	outputs []*structpb.Struct
+	schema                 string
+	inputReaderInterceptor *inputReaderInterceptor
+	usageHandler           UsageHandler
 }
 
 func (ow *outputWriterInterceptor) Write(ctx context.Context, outputs []*structpb.Struct) (err error) {
-	ow.outputs = outputs
-	return ow.OutputWriter.Write(ctx, outputs)
-}
 
-func (ow *outputWriterInterceptor) GetOutputs(ctx context.Context) (outputs []*structpb.Struct, err error) {
-	return ow.outputs, nil
+	if err := Validate(outputs, ow.schema, "outputs"); err != nil {
+		return err
+	}
+
+	if err := ow.usageHandler.Collect(ctx, ow.inputReaderInterceptor.inputs, outputs); err != nil {
+		return err
+	}
+
+	return ow.OutputWriter.Write(ctx, outputs)
+
 }
 
 // Execute wraps the execution method with validation and usage collection.
 func (e *ExecutionWrapper) Execute(ctx context.Context, ir InputReader, ow OutputWriter) error {
-
-	inputs, err := ir.Read(ctx)
-	if err != nil {
-		return err
-	}
-	if err := Validate(inputs, e.GetTaskInputSchema(), "inputs"); err != nil {
-		return err
-	}
 
 	newUH := e.GetComponent().UsageHandlerCreator()
 	h, err := newUH(e)
@@ -45,26 +67,20 @@ func (e *ExecutionWrapper) Execute(ctx context.Context, ir InputReader, ow Outpu
 		return err
 	}
 
-	if err := h.Check(ctx, inputs); err != nil {
-		return err
+	iri := &inputReaderInterceptor{
+		InputReader:  ir,
+		schema:       e.GetTaskInputSchema(),
+		usageHandler: h,
 	}
 
-	owi := &outputWriterInterceptor{OutputWriter: ow}
-	err = e.IExecution.Execute(ctx, ir, owi)
-	if err != nil {
-		return err
+	owi := &outputWriterInterceptor{
+		OutputWriter:           ow,
+		schema:                 e.GetTaskOutputSchema(),
+		inputReaderInterceptor: iri,
+		usageHandler:           h,
 	}
 
-	outputs, err := owi.GetOutputs(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := Validate(outputs, e.GetTaskOutputSchema(), "outputs"); err != nil {
-		return err
-	}
-
-	if err := h.Collect(ctx, inputs, outputs); err != nil {
+	if err := e.IExecution.Execute(ctx, iri, owi); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Because

- We can encapsulate the usage handler and data validator within `InputReader` and `OutputWriter`.

This commit 

- Refactors the code.