### PR TITLE
refactor(document): export operator functions

### DIFF
--- a/operator/document/v0/convert.go
+++ b/operator/document/v0/convert.go
@@ -110,7 +110,7 @@ func isSupportedByDocconvConvert(contentType string) bool {
 	return supportedByDocconvConvertMimeTypes[contentType]
 }
 
-func convertToText(input ConvertToTextInput) (ConvertToTextOutput, error) {
+func ConvertToText(input ConvertToTextInput) (ConvertToTextOutput, error) {
 
 	contentType, err := util.GetContentTypeFromBase64(input.Document)
 	if err != nil {

--- a/operator/document/v0/convert_document_to_markdown_test.go
+++ b/operator/document/v0/convert_document_to_markdown_test.go
@@ -41,7 +41,7 @@ func TestConvertDocumentToMarkdown(t *testing.T) {
 
 			base64DataURI := fmt.Sprintf("data:%s;base64,%s", mimeTypeByExtension(test.filepath), base64.StdEncoding.EncodeToString(fileContent))
 
-			inputStruct := convertDocumentToMarkdownInput{
+			inputStruct := ConvertDocumentToMarkdownInput{
 				Document:        base64DataURI,
 				DisplayImageTag: false,
 				Converter:       "instill",
@@ -56,7 +56,7 @@ func TestConvertDocumentToMarkdown(t *testing.T) {
 			output, err := e.convertDocumentToMarkdown(input)
 			c.Assert(err, quicktest.IsNil)
 
-			outputStruct := convertDocumentToMarkdownOutput{}
+			outputStruct := ConvertDocumentToMarkdownOutput{}
 			err = base.ConvertFromStructpb(output, &outputStruct)
 			c.Assert(err, quicktest.IsNil)
 			c.Assert(outputStruct.Body, quicktest.DeepEquals, "This is test file")
@@ -81,7 +81,7 @@ func mimeTypeByExtension(filepath string) string {
 	}
 }
 
-func fakeGetMarkdownTransformer(fileExtension string, inputStruct convertDocumentToMarkdownInput) (MarkdownTransformer, error) {
+func fakeGetMarkdownTransformer(fileExtension string, inputStruct *ConvertDocumentToMarkdownInput) (MarkdownTransformer, error) {
 	return FakeMarkdownTransformer{}, nil
 }
 

--- a/operator/document/v0/convert_to_images.go
+++ b/operator/document/v0/convert_to_images.go
@@ -22,14 +22,7 @@ type ConvertPDFToImagesOutput struct {
 	Filenames []string `json:"filenames"`
 }
 
-func (e *execution) convertPDFToImages(input *structpb.Struct) (*structpb.Struct, error) {
-
-	inputStruct := ConvertPDFToImagesInput{}
-	err := base.ConvertFromStructpb(input, &inputStruct)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert input struct: %w", err)
-	}
-
+func ConvertPDFToImage(inputStruct *ConvertPDFToImagesInput) (*ConvertPDFToImagesOutput, error) {
 	base64String := strings.Split(inputStruct.PDF, ",")[1]
 	fileContent, err := base64.StdEncoding.DecodeString(base64String)
 
@@ -71,6 +64,21 @@ func (e *execution) convertPDFToImages(input *structpb.Struct) (*structpb.Struct
 	outputStruct := ConvertPDFToImagesOutput{
 		Images:    images,
 		Filenames: filenames,
+	}
+	return &outputStruct, nil
+}
+
+func (e *execution) convertPDFToImages(input *structpb.Struct) (*structpb.Struct, error) {
+
+	inputStruct := ConvertPDFToImagesInput{}
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert input struct: %w", err)
+	}
+
+	outputStruct, err := ConvertPDFToImage(&inputStruct)
+	if err != nil {
+		return nil, err
 	}
 
 	return base.ConvertToStructpb(outputStruct)

--- a/operator/document/v0/main.go
+++ b/operator/document/v0/main.go
@@ -38,8 +38,10 @@ type component struct {
 type execution struct {
 	base.ComponentExecution
 	execute                func(*structpb.Struct) (*structpb.Struct, error)
-	getMarkdownTransformer func(fileExtension string, inputStruct convertDocumentToMarkdownInput) (MarkdownTransformer, error)
+	getMarkdownTransformer MarkdownTransformerGetterFunc
 }
+
+type MarkdownTransformerGetterFunc func(fileExtension string, inputStruct *ConvertDocumentToMarkdownInput) (MarkdownTransformer, error)
 
 func Init(bc base.Component) *component {
 	once.Do(func() {
@@ -58,7 +60,7 @@ func (e *execution) convertToText(input *structpb.Struct) (*structpb.Struct, err
 	if err != nil {
 		return nil, err
 	}
-	outputStruct, err := convertToText(inputStruct)
+	outputStruct, err := ConvertToText(inputStruct)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +76,7 @@ func (e *execution) convertToText(input *structpb.Struct) (*structpb.Struct, err
 func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution, error) {
 	e := &execution{
 		ComponentExecution:     x,
-		getMarkdownTransformer: getMarkdownTransformer,
+		getMarkdownTransformer: GetMarkdownTransformer,
 	}
 
 	switch x.Task {


### PR DESCRIPTION
Because

- We need to directly use certain functions from the document operator in the pipeline-backend.

This commit

- Exports the necessary operator functions.