### PR TITLE
feat: make the API key be optional for Instill-Credit-supported component

### DIFF
--- a/ai/anthropic/v0/README.mdx
+++ b/ai/anthropic/v0/README.mdx
@@ -30,7 +30,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api-key` | string | Fill in your Anthropic API key. To find your keys, visit the Anthropic console page. |
+| API Key | `api-key` | string | Fill in your Anthropic API key. To find your keys, visit the Anthropic console page. |
 
 
 

--- a/ai/anthropic/v0/component_test.go
+++ b/ai/anthropic/v0/component_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	apiKey  = "123"
-	errResp = `
+	apiKey        = "123"
+	instillSecret = "instill-credential-key"
+	errResp       = `
 {
   "error": {
     "message": "Incorrect API key provided."
@@ -32,8 +33,7 @@ func TestComponent_Execute(t *testing.T) {
 	ctx := context.Background()
 
 	bc := base.Component{}
-	cmp := Init(bc)
-
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 	testcases := []struct {
 		name        string
 		task        string
@@ -110,7 +110,7 @@ func TestComponent_Connection(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	c.Run("nok - error", func(c *qt.C) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -191,7 +191,7 @@ func TestComponent_Generation(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	mockHistory := []message{
 		{Role: "user", Content: []content{{Type: "text", Text: "Answer the following question in traditional chinses"}}},

--- a/ai/anthropic/v0/config/setup.json
+++ b/ai/anthropic/v0/config/setup.json
@@ -17,9 +17,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "api-key"
-  ],
+  "required": [],
   "instillEditOnNodeFields": [
     "api-key"
   ],

--- a/ai/anthropic/v0/main.go
+++ b/ai/anthropic/v0/main.go
@@ -185,9 +185,14 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // credentials injected during initialization and, if so, returns a new setup
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != "" && apiKey != base.SecretKeyword {
-		return setup, false, nil
+	if setup == nil || setup.Fields == nil {
+		setup = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+	if v, ok := setup.GetFields()[cfgAPIKey]; ok {
+		apiKey := v.GetStringValue()
+		if apiKey != "" && apiKey != base.SecretKeyword {
+			return setup, false, nil
+		}
 	}
 
 	if c.instillAPIKey == "" {

--- a/ai/anthropic/v0/main.go
+++ b/ai/anthropic/v0/main.go
@@ -186,7 +186,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
 	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != base.SecretKeyword {
+	if apiKey != "" && apiKey != base.SecretKeyword {
 		return setup, false, nil
 	}
 

--- a/ai/cohere/v0/README.mdx
+++ b/ai/cohere/v0/README.mdx
@@ -32,7 +32,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api-key` | string | Fill in your Cohere API key. To find your keys, visit the Cohere dashboard page. |
+| API Key | `api-key` | string | Fill in your Cohere API key. To find your keys, visit the Cohere dashboard page. |
 
 
 

--- a/ai/cohere/v0/component_test.go
+++ b/ai/cohere/v0/component_test.go
@@ -15,14 +15,15 @@ import (
 )
 
 const (
-	apiKey = "cohere-api-key"
+	apiKey        = "cohere-api-key"
+	instillSecret = "instill-credential-key"
 )
 
 func TestComponent_Execute(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{Logger: zap.NewNop()}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	c.Run("ok - supported task", func(c *qt.C) {
 		task := TextGenerationTask
@@ -68,7 +69,7 @@ func TestComponent_Tasks(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{Logger: zap.NewNop()}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 	ctx := context.Background()
 
 	commandTc := struct {

--- a/ai/cohere/v0/config/setup.json
+++ b/ai/cohere/v0/config/setup.json
@@ -17,9 +17,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "api-key"
-  ],
+  "required": [],
   "instillEditOnNodeFields": [
     "api-key"
   ],

--- a/ai/cohere/v0/main.go
+++ b/ai/cohere/v0/main.go
@@ -99,9 +99,14 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // credentials injected during initialization and, if so, returns a new setup
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != "" && apiKey != base.SecretKeyword {
-		return setup, false, nil
+	if setup == nil || setup.Fields == nil {
+		setup = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+	if v, ok := setup.GetFields()[cfgAPIKey]; ok {
+		apiKey := v.GetStringValue()
+		if apiKey != "" && apiKey != base.SecretKeyword {
+			return setup, false, nil
+		}
 	}
 
 	if c.instillAPIKey == "" {

--- a/ai/cohere/v0/main.go
+++ b/ai/cohere/v0/main.go
@@ -100,7 +100,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
 	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != base.SecretKeyword {
+	if apiKey != "" && apiKey != base.SecretKeyword {
 		return setup, false, nil
 	}
 

--- a/ai/fireworksai/v0/README.mdx
+++ b/ai/fireworksai/v0/README.mdx
@@ -31,7 +31,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api-key` | string | Fill in your Fireworks AI API key. To find your keys, visit the Fireworks AI API Keys page. |
+| API Key | `api-key` | string | Fill in your Fireworks AI API key. To find your keys, visit the Fireworks AI API Keys page. |
 
 
 

--- a/ai/fireworksai/v0/component_test.go
+++ b/ai/fireworksai/v0/component_test.go
@@ -7,11 +7,13 @@ import (
 	"github.com/instill-ai/component/base"
 )
 
+const instillSecret = "instill-credential-key"
+
 func TestComponent_Execute(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	c.Run("ok - supported chat task", func(c *qt.C) {
 		_, err := cmp.CreateExecution(base.ComponentExecution{

--- a/ai/fireworksai/v0/config/setup.json
+++ b/ai/fireworksai/v0/config/setup.json
@@ -17,9 +17,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "api-key"
-  ],
+  "required": [],
   "instillEditOnNodeFields": [
     "api-key"
   ],

--- a/ai/fireworksai/v0/main.go
+++ b/ai/fireworksai/v0/main.go
@@ -95,9 +95,14 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // credentials injected during initialization and, if so, returns a new setup
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != "" && apiKey != base.SecretKeyword {
-		return setup, false, nil
+	if setup == nil || setup.Fields == nil {
+		setup = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+	if v, ok := setup.GetFields()[cfgAPIKey]; ok {
+		apiKey := v.GetStringValue()
+		if apiKey != "" && apiKey != base.SecretKeyword {
+			return setup, false, nil
+		}
 	}
 
 	if c.instillAPIKey == "" {

--- a/ai/fireworksai/v0/main.go
+++ b/ai/fireworksai/v0/main.go
@@ -96,7 +96,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
 	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != base.SecretKeyword {
+	if apiKey != "" && apiKey != base.SecretKeyword {
 		return setup, false, nil
 	}
 

--- a/ai/groq/v0/README.mdx
+++ b/ai/groq/v0/README.mdx
@@ -30,7 +30,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api-key` | string | Fill in your GroqCloud API key. To find your keys, visit the GroqCloud API Keys page. |
+| API Key | `api-key` | string | Fill in your GroqCloud API key. To find your keys, visit the GroqCloud API Keys page. |
 
 
 

--- a/ai/groq/v0/component_test.go
+++ b/ai/groq/v0/component_test.go
@@ -17,14 +17,15 @@ import (
 )
 
 const (
-	MockAPIKey = "### Mock API Key ###"
+	MockAPIKey    = "### Mock API Key ###"
+	instillSecret = "instill-credential-key"
 )
 
 func TestComponent_Execute(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{Logger: zap.NewNop()}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	c.Run("ok - supported task", func(c *qt.C) {
 		task := TaskTextGenerationChat
@@ -51,7 +52,7 @@ func TestComponent_Tasks(t *testing.T) {
 	mc := minimock.NewController(t)
 	c := qt.New(t)
 	bc := base.Component{Logger: zap.NewNop()}
-	connector := Init(bc)
+	connector := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 	ctx := context.Background()
 
 	GroqClientMock := NewGroqClientInterfaceMock(mc)

--- a/ai/groq/v0/config/setup.json
+++ b/ai/groq/v0/config/setup.json
@@ -17,9 +17,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "api-key"
-  ],
+  "required": [],
   "instillEditOnNodeFields": [
     "api-key"
   ],

--- a/ai/groq/v0/main.go
+++ b/ai/groq/v0/main.go
@@ -103,9 +103,14 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // credentials injected during initialization and, if so, returns a new setup
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != "" && apiKey != base.SecretKeyword {
-		return setup, false, nil
+	if setup == nil || setup.Fields == nil {
+		setup = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+	if v, ok := setup.GetFields()[cfgAPIKey]; ok {
+		apiKey := v.GetStringValue()
+		if apiKey != "" && apiKey != base.SecretKeyword {
+			return setup, false, nil
+		}
 	}
 
 	if c.instillAPIKey == "" {

--- a/ai/groq/v0/main.go
+++ b/ai/groq/v0/main.go
@@ -104,7 +104,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
 	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != base.SecretKeyword {
+	if apiKey != "" && apiKey != base.SecretKeyword {
 		return setup, false, nil
 	}
 

--- a/ai/mistralai/v0/README.mdx
+++ b/ai/mistralai/v0/README.mdx
@@ -31,7 +31,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api-key` | string | Fill in your Mistral API key. To find your keys, visit the Mistral AI platform page. |
+| API Key | `api-key` | string | Fill in your Mistral API key. To find your keys, visit the Mistral AI platform page. |
 
 
 

--- a/ai/mistralai/v0/component_test.go
+++ b/ai/mistralai/v0/component_test.go
@@ -66,14 +66,15 @@ func (m *MockMistralClient) Chat(model string, messages []mistralSDK.ChatMessage
 }
 
 const (
-	apiKey = "### MOCK API KEY ###"
+	apiKey        = "### MOCK API KEY ###"
+	instillSecret = "instill-credential-key"
 )
 
 func TestComponent_Execute(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{Logger: zap.NewNop()}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	c.Run("ok - supported task", func(c *qt.C) {
 		task := TextGenerationTask
@@ -109,7 +110,7 @@ func TestComponent_Tasks(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{Logger: zap.NewNop()}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 	ctx := context.Background()
 
 	chatTc := struct {

--- a/ai/mistralai/v0/config/setup.json
+++ b/ai/mistralai/v0/config/setup.json
@@ -17,9 +17,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "api-key"
-  ],
+  "required": [],
   "instillEditOnNodeFields": [
     "api-key"
   ],

--- a/ai/mistralai/v0/main.go
+++ b/ai/mistralai/v0/main.go
@@ -91,7 +91,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
 	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != base.SecretKeyword {
+	if apiKey != "" && apiKey != base.SecretKeyword {
 		return setup, false, nil
 	}
 

--- a/ai/mistralai/v0/main.go
+++ b/ai/mistralai/v0/main.go
@@ -90,9 +90,14 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // credentials injected during initialization and, if so, returns a new setup
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != "" && apiKey != base.SecretKeyword {
-		return setup, false, nil
+	if setup == nil || setup.Fields == nil {
+		setup = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+	if v, ok := setup.GetFields()[cfgAPIKey]; ok {
+		apiKey := v.GetStringValue()
+		if apiKey != "" && apiKey != base.SecretKeyword {
+			return setup, false, nil
+		}
 	}
 
 	if c.instillAPIKey == "" {

--- a/ai/openai/v0/README.mdx
+++ b/ai/openai/v0/README.mdx
@@ -34,7 +34,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api-key` | string | Fill in your OpenAI API key. To find your keys, visit your OpenAI's API Keys page. |
+| API Key | `api-key` | string | Fill in your OpenAI API key. To find your keys, visit your OpenAI's API Keys page. |
 | Organization ID | `organization` | string | Specify which organization is used for the requests. Usage will count against the specified organization's subscription quota. |
 
 

--- a/ai/openai/v0/component_test.go
+++ b/ai/openai/v0/component_test.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	apiKey  = "123"
-	org     = "org1"
-	errResp = `
+	apiKey        = "123"
+	instillSecret = "instill-credential-key"
+	org           = "org1"
+	errResp       = `
 {
   "error": {
     "message": "Incorrect API key provided."
@@ -34,7 +35,7 @@ func TestComponent_Execute(t *testing.T) {
 	ctx := context.Background()
 
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	testcases := []struct {
 		name        string
@@ -152,7 +153,7 @@ func TestComponent_Test(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	c.Run("nok - error", func(c *qt.C) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -232,7 +233,7 @@ func TestComponent_WithConfig(t *testing.T) {
 	c.Run("ok - without secret", func(c *qt.C) {
 		c.Cleanup(cleanupConn)
 
-		cmp := Init(bc)
+		cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 		setup, err := structpb.NewStruct(map[string]any{
 			"base-path": "foo/bar",

--- a/ai/openai/v0/config/setup.json
+++ b/ai/openai/v0/config/setup.json
@@ -29,9 +29,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "api-key"
-  ],
+  "required": [],
   "instillEditOnNodeFields": [
     "api-key"
   ],

--- a/ai/openai/v0/main.go
+++ b/ai/openai/v0/main.go
@@ -92,9 +92,14 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // credentials injected during initialization and, if so, returns a new setup
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != "" && apiKey != base.SecretKeyword {
-		return setup, false, nil
+	if setup == nil || setup.Fields == nil {
+		setup = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+	if v, ok := setup.GetFields()[cfgAPIKey]; ok {
+		apiKey := v.GetStringValue()
+		if apiKey != "" && apiKey != base.SecretKeyword {
+			return setup, false, nil
+		}
 	}
 
 	if c.instillAPIKey == "" {
@@ -217,6 +222,10 @@ func (e *execution) Execute(ctx context.Context, in base.InputReader, out base.O
 				return err
 			}
 
+			if restyResp.StatusCode() != 200 {
+				res := restyResp.Body()
+				return fmt.Errorf("send request to openai error with error code: %d, msg %s", restyResp.StatusCode(), res)
+			}
 			scanner := bufio.NewScanner(restyResp.RawResponse.Body)
 
 			outputStruct := TextCompletionOutput{}

--- a/ai/openai/v0/main.go
+++ b/ai/openai/v0/main.go
@@ -93,7 +93,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
 	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != base.SecretKeyword {
+	if apiKey != "" && apiKey != base.SecretKeyword {
 		return setup, false, nil
 	}
 

--- a/ai/stabilityai/v0/README.mdx
+++ b/ai/stabilityai/v0/README.mdx
@@ -31,7 +31,7 @@ The component configuration is defined and maintained [here](https://github.com/
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| API Key (required) | `api-key` | string | Fill in your Stability AI API key. To find your keys, visit <a href="https://platform.stability.ai/account/keys">here</a> |
+| API Key | `api-key` | string | Fill in your Stability AI API key. To find your keys, visit <a href="https://platform.stability.ai/account/keys">here</a> |
 
 
 

--- a/ai/stabilityai/v0/component_test.go
+++ b/ai/stabilityai/v0/component_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	apiKey  = "123"
-	errResp = `
+	apiKey        = "123"
+	instillSecret = "instill-credential-key"
+	errResp       = `
 {
   "id": "6e958442e7911ffb2e0bf89c6efe804f",
   "message": "Incorrect API key provided",
@@ -48,7 +49,7 @@ func TestComponent_ExecuteImageFromText(t *testing.T) {
 	engine := "engine"
 
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	testcases := []struct {
 		name      string
@@ -163,7 +164,7 @@ func TestComponent_ExecuteImageFromImage(t *testing.T) {
 	engine := "engine"
 
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	testcases := []struct {
 		name      string
@@ -273,7 +274,7 @@ func TestComponent_Test(t *testing.T) {
 	c := qt.New(t)
 
 	bc := base.Component{}
-	cmp := Init(bc)
+	cmp := Init(bc).WithInstillCredentials(map[string]any{"apikey": instillSecret})
 
 	c.Run("nok - error", func(c *qt.C) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/ai/stabilityai/v0/config/setup.json
+++ b/ai/stabilityai/v0/config/setup.json
@@ -17,9 +17,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "api-key"
-  ],
+  "required": [],
   "instillEditOnNodeFields": [
     "api-key"
   ],

--- a/ai/stabilityai/v0/main.go
+++ b/ai/stabilityai/v0/main.go
@@ -68,7 +68,7 @@ func (c *component) WithInstillCredentials(s map[string]any) *component {
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
 	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != base.SecretKeyword {
+	if apiKey != "" && apiKey != base.SecretKeyword {
 		return setup, false, nil
 	}
 

--- a/ai/stabilityai/v0/main.go
+++ b/ai/stabilityai/v0/main.go
@@ -67,9 +67,14 @@ func (c *component) WithInstillCredentials(s map[string]any) *component {
 // credentials injected during initialization and, if so, returns a new setup
 // with the secret credential values.
 func (c *component) resolveSetup(setup *structpb.Struct) (*structpb.Struct, bool, error) {
-	apiKey := setup.GetFields()[cfgAPIKey].GetStringValue()
-	if apiKey != "" && apiKey != base.SecretKeyword {
-		return setup, false, nil
+	if setup == nil || setup.Fields == nil {
+		setup = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+	if v, ok := setup.GetFields()[cfgAPIKey]; ok {
+		apiKey := v.GetStringValue()
+		if apiKey != "" && apiKey != base.SecretKeyword {
+			return setup, false, nil
+		}
 	}
 
 	if c.instillAPIKey == "" {


### PR DESCRIPTION
Because

- In the new low-code editor, users need to type the recipe manually. Asking users to write `${secret.INSTILL_SECRET}` is not user-friendly. We decided to make these fields optional; if the key is empty, the component will use built-in keys.

This commit

- Makes the API key optional for Instill-Credit-supported components.