### PR TITLE
feat(document): improve convert to markdown

### DIFF
--- a/operator/document/v0/README.mdx
+++ b/operator/document/v0/README.mdx
@@ -40,6 +40,7 @@ Convert document to text in Markdown format.
 | Task ID (required) | `task` | string | `TASK_CONVERT_TO_MARKDOWN` |
 | Document (required) | `document` | string | Base64 encoded PDF/DOCX/DOC/PPTX/PPT/HTML/XLSX to be converted to text in Markdown format |
 | Filename | `filename` | string | The name of the file, please remember to add the file extension in the end of file name. e.g. 'example.pdf' |
+| Display Image Tag | `display-image-tag` | boolean | Whether to display image tag in the markdown text. Default is 'false'. It is only applicable for convert-2024-08-28 converter. And, it is only applicable for the type of PPTX/PPT/DOCX/DOC/PDF. |
 
 
 

--- a/operator/document/v0/README.mdx
+++ b/operator/document/v0/README.mdx
@@ -48,6 +48,7 @@ Convert document to text in Markdown format.
 | :--- | :--- | :--- | :--- |
 | Body | `body` | string | Markdown text converted from the PDF document |
 | Filename (optional) | `filename` | string | The name of the file |
+| Images (optional) | `images` | array[string] | Images extracted from the document |
 
 
 

--- a/operator/document/v0/config/tasks.json
+++ b/operator/document/v0/config/tasks.json
@@ -70,6 +70,16 @@
           "instillUIOrder": 1,
           "title": "Filename",
           "type": "string"
+        },
+        "images": {
+          "description": "Images extracted from the document",
+          "instillFormat": "array:image/*",
+          "instillUIOrder": 2,
+          "items": {
+            "type": "string"
+          },
+          "title": "Images",
+          "type": "array"
         }
       },
       "required": [

--- a/operator/document/v0/config/tasks.json
+++ b/operator/document/v0/config/tasks.json
@@ -33,6 +33,17 @@
           ],
           "title": "Filename",
           "type": "string"
+        },
+        "display-image-tag": {
+          "default": false,
+          "description": "Whether to display image tag in the markdown text. Default is 'false'. It is only applicable for convert-2024-08-28 converter. And, it is only applicable for the type of PPTX/PPT/DOCX/DOC/PDF.",
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "reference",
+            "value"
+          ],
+          "title": "Display Image Tag",
+          "type": "boolean"
         }
       },
       "required": [

--- a/operator/document/v0/convert_document_to_markdown.go
+++ b/operator/document/v0/convert_document_to_markdown.go
@@ -12,7 +12,6 @@ import (
 type ConvertDocumentToMarkdownInput struct {
 	Document        string `json:"document"`
 	DisplayImageTag bool   `json:"display-image-tag"`
-	Converter       string `json:"converter"`
 	Filename        string `json:"filename"`
 }
 
@@ -82,28 +81,26 @@ func GetMarkdownTransformer(fileExtension string, inputStruct *ConvertDocumentTo
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
 			DisplayImageTag:   inputStruct.DisplayImageTag,
-			Converter:         inputStruct.Converter,
+			PDFConvertFunc:    getPDFConvertFunc("pdfplumber"),
 		}, nil
 	case "doc", "docx":
 		return DocxDocToMarkdownTransformer{
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
 			DisplayImageTag:   inputStruct.DisplayImageTag,
-			Converter:         inputStruct.Converter,
+			PDFConvertFunc:    getPDFConvertFunc("pdfplumber"),
 		}, nil
 	case "ppt", "pptx":
 		return PptPptxToMarkdownTransformer{
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
 			DisplayImageTag:   inputStruct.DisplayImageTag,
-			Converter:         inputStruct.Converter,
+			PDFConvertFunc:    getPDFConvertFunc("pdfplumber"),
 		}, nil
 	case "html":
 		return HTMLToMarkdownTransformer{
 			Base64EncodedText: inputStruct.Document,
 			FileExtension:     fileExtension,
-			DisplayImageTag:   inputStruct.DisplayImageTag,
-			Converter:         inputStruct.Converter,
 		}, nil
 	case "xlsx":
 		return XlsxToMarkdownTransformer{
@@ -111,5 +108,13 @@ func GetMarkdownTransformer(fileExtension string, inputStruct *ConvertDocumentTo
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported file type")
+	}
+}
+
+// We could provide more converters in the future. For now, we only have one.
+func getPDFConvertFunc(converter string) func(string, bool) (string, error) {
+	switch converter {
+	default:
+		return convertPDFToMarkdownWithPDFPlumber
 	}
 }

--- a/operator/document/v0/convert_document_to_markdown.go
+++ b/operator/document/v0/convert_document_to_markdown.go
@@ -18,7 +18,7 @@ type ConvertDocumentToMarkdownInput struct {
 type ConvertDocumentToMarkdownOutput struct {
 	Body     string   `json:"body"`
 	Filename string   `json:"filename"`
-	Images   []string `json:"images"`
+	Images   []string `json:"images,omitempty"`
 }
 
 func ConvertDocumentToMarkdown(inputStruct *ConvertDocumentToMarkdownInput, transformerGetter MarkdownTransformerGetterFunc) (*ConvertDocumentToMarkdownOutput, error) {

--- a/operator/document/v0/convert_document_to_markdown.go
+++ b/operator/document/v0/convert_document_to_markdown.go
@@ -16,8 +16,9 @@ type ConvertDocumentToMarkdownInput struct {
 }
 
 type ConvertDocumentToMarkdownOutput struct {
-	Body     string `json:"body"`
-	Filename string `json:"filename"`
+	Body     string   `json:"body"`
+	Filename string   `json:"filename"`
+	Images   []string `json:"images"`
 }
 
 func ConvertDocumentToMarkdown(inputStruct *ConvertDocumentToMarkdownInput, transformerGetter MarkdownTransformerGetterFunc) (*ConvertDocumentToMarkdownOutput, error) {
@@ -38,13 +39,14 @@ func ConvertDocumentToMarkdown(inputStruct *ConvertDocumentToMarkdownInput, tran
 	if err != nil {
 		return nil, err
 	}
-	extractedTextInMarkdownFormat, err := transformer.Transform()
+	converterOutput, err := transformer.Transform()
 	if err != nil {
 		return nil, err
 	}
 
 	outputStruct := &ConvertDocumentToMarkdownOutput{
-		Body: extractedTextInMarkdownFormat,
+		Body:   converterOutput.Body,
+		Images: converterOutput.Images,
 	}
 
 	if inputStruct.Filename != "" {
@@ -112,7 +114,7 @@ func GetMarkdownTransformer(fileExtension string, inputStruct *ConvertDocumentTo
 }
 
 // We could provide more converters in the future. For now, we only have one.
-func getPDFConvertFunc(converter string) func(string, bool) (string, error) {
+func getPDFConvertFunc(converter string) func(string, bool) (converterOutput, error) {
 	switch converter {
 	default:
 		return convertPDFToMarkdownWithPDFPlumber

--- a/operator/document/v0/convert_document_to_markdown_test.go
+++ b/operator/document/v0/convert_document_to_markdown_test.go
@@ -44,7 +44,6 @@ func TestConvertDocumentToMarkdown(t *testing.T) {
 			inputStruct := ConvertDocumentToMarkdownInput{
 				Document:        base64DataURI,
 				DisplayImageTag: false,
-				Converter:       "instill",
 			}
 			input, err := base.ConvertToStructpb(inputStruct)
 			c.Assert(err, quicktest.IsNil)

--- a/operator/document/v0/convert_document_to_markdown_test.go
+++ b/operator/document/v0/convert_document_to_markdown_test.go
@@ -33,6 +33,10 @@ func TestConvertDocumentToMarkdown(t *testing.T) {
 			name:     "Convert PPTX file",
 			filepath: "testdata/test.pptx",
 		},
+		{
+			name:     "Convert XLSX file",
+			filepath: "testdata/test.xlsx",
+		},
 	}
 	for _, test := range tests {
 		c.Run(test.name, func(c *quicktest.C) {
@@ -75,6 +79,8 @@ func mimeTypeByExtension(filepath string) string {
 		return "text/html"
 	case "testdata/test.pptx":
 		return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	case "testdata/test.xlsx":
+		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 	default:
 		return ""
 	}
@@ -91,6 +97,17 @@ type FakeMarkdownTransformer struct {
 	Converter         string
 }
 
-func (f FakeMarkdownTransformer) Transform() (string, error) {
-	return "This is test file", nil
+func (f FakeMarkdownTransformer) Transform() (converterOutput, error) {
+	b, err := os.ReadFile("testdata/test.png")
+	if err != nil {
+		return converterOutput{}, err
+	}
+
+	base64DataURI := fmt.Sprintf("data:image/png;base64,%s", base64.StdEncoding.EncodeToString(b))
+
+	output := converterOutput{
+		Body:   "This is test file",
+		Images: []string{base64DataURI},
+	}
+	return output, nil
 }

--- a/operator/document/v0/main.go
+++ b/operator/document/v0/main.go
@@ -106,6 +106,9 @@ func (e *execution) Execute(ctx context.Context, in base.InputReader, out base.O
 			return err
 		}
 
+		// TODO: Take it off
+		fmt.Println("==== \n\n \nOutput: ", output, "\n \n \n====")
+
 		outputs[i] = output
 	}
 	return out.Write(ctx, outputs)

--- a/operator/document/v0/main.go
+++ b/operator/document/v0/main.go
@@ -26,9 +26,9 @@ var (
 	//go:embed config/tasks.json
 	tasksJSON []byte
 	//go:embed python/transformPDFToMarkdown.py
-	pythonCode string
-	once       sync.Once
-	comp       *component
+	pythonPDFPlumberConverter string
+	once                      sync.Once
+	comp                      *component
 )
 
 type component struct {

--- a/operator/document/v0/main.go
+++ b/operator/document/v0/main.go
@@ -106,9 +106,6 @@ func (e *execution) Execute(ctx context.Context, in base.InputReader, out base.O
 			return err
 		}
 
-		// TODO: Take it off
-		fmt.Println("==== \n\n \nOutput: ", output, "\n \n \n====")
-
 		outputs[i] = output
 	}
 	return out.Write(ctx, outputs)

--- a/operator/document/v0/pdf_to_markdown_converter.go
+++ b/operator/document/v0/pdf_to_markdown_converter.go
@@ -2,27 +2,34 @@ package document
 
 import (
 	"encoding/json"
+	"fmt"
 	"os/exec"
 
 	"github.com/instill-ai/component/base"
 )
 
-func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool) (string, error) {
+type converterOutput struct {
+	Body   string   `json:"body"`
+	Images []string `json:"images"`
+}
+
+func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool) (converterOutput, error) {
 
 	paramsJSON, err := json.Marshal(map[string]interface{}{
 		"PDF":               base.TrimBase64Mime(base64Text),
 		"display-image-tag": displayImageTag,
 	})
+	var output converterOutput
 
 	if err != nil {
-		return "", err
+		return output, fmt.Errorf("failed to marshal params: %w", err)
 	}
 
 	cmdRunner := exec.Command(pythonInterpreter, "-c", pythonPDFPlumberConverter)
 	stdin, err := cmdRunner.StdinPipe()
 
 	if err != nil {
-		return "", err
+		return output, fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 	errChan := make(chan error, 1)
 	go func() {
@@ -37,18 +44,21 @@ func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool)
 
 	outputBytes, err := cmdRunner.CombinedOutput()
 	if err != nil {
-		return "", err
+		return output, fmt.Errorf("failed to run python script: %w", err)
 	}
 
 	writeErr := <-errChan
 	if writeErr != nil {
-		return "", writeErr
+		return output, fmt.Errorf("failed to write to stdin: %w", writeErr)
 	}
 
-	var output pythonRunnerOutput
 	err = json.Unmarshal(outputBytes, &output)
 	if err != nil {
-		return "", err
+		return output, fmt.Errorf("failed to unmarshal output: %w", err)
 	}
-	return output.Body, nil
+
+	// TODO: Take it off
+	fmt.Println("===== \n\n\n output", output, "\n\n\n =====")
+
+	return output, nil
 }

--- a/operator/document/v0/pdf_to_markdown_converter.go
+++ b/operator/document/v0/pdf_to_markdown_converter.go
@@ -1,0 +1,54 @@
+package document
+
+import (
+	"encoding/json"
+	"os/exec"
+
+	"github.com/instill-ai/component/base"
+)
+
+func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool) (string, error) {
+
+	paramsJSON, err := json.Marshal(map[string]interface{}{
+		"PDF":               base.TrimBase64Mime(base64Text),
+		"display-image-tag": displayImageTag,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	cmdRunner := exec.Command(pythonInterpreter, "-c", pythonPDFPlumberConverter)
+	stdin, err := cmdRunner.StdinPipe()
+
+	if err != nil {
+		return "", err
+	}
+	errChan := make(chan error, 1)
+	go func() {
+		defer stdin.Close()
+		_, err := stdin.Write(paramsJSON)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		errChan <- nil
+	}()
+
+	outputBytes, err := cmdRunner.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	writeErr := <-errChan
+	if writeErr != nil {
+		return "", writeErr
+	}
+
+	var output pythonRunnerOutput
+	err = json.Unmarshal(outputBytes, &output)
+	if err != nil {
+		return "", err
+	}
+	return output.Body, nil
+}

--- a/operator/document/v0/pdf_to_markdown_converter.go
+++ b/operator/document/v0/pdf_to_markdown_converter.go
@@ -11,6 +11,7 @@ import (
 type converterOutput struct {
 	Body   string   `json:"body"`
 	Images []string `json:"images"`
+	Error  string   `json:"error"`
 }
 
 func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool) (converterOutput, error) {
@@ -53,12 +54,9 @@ func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool)
 	}
 
 	err = json.Unmarshal(outputBytes, &output)
-	if err != nil {
-		return output, fmt.Errorf("failed to unmarshal output: %w", err)
+	if err != nil || output.Error != "" {
+		return output, fmt.Errorf("failed to unmarshal output: %w, %s", err, output.Error)
 	}
-
-	// TODO: Take it off
-	fmt.Println("===== \n\n\n output", output, "\n\n\n =====")
 
 	return output, nil
 }

--- a/operator/document/v0/python/transformPDFToMarkdown.py
+++ b/operator/document/v0/python/transformPDFToMarkdown.py
@@ -56,11 +56,6 @@ class PdfTransformer:
 		self.result = self.transform_line_to_markdown(self.lines)
 		return self.result
 
-		# export .md file
-		# file_name = "pdfTransform/output/" + self.path.split("/")[-1].replace(".pdf", ".md")
-		# with open(file_name, "w") as f:
-		#     f.write(self.result)
-
 	# It can add more calculation for the future development when we want to extend more use cases.
 	def process_line(self, lines, page_number):
 		for idx, line in enumerate(lines):
@@ -81,10 +76,6 @@ class PdfTransformer:
 				table_info["text"] = text
 				table_info["page_number"] = page.page_number
 				self.tables.append(table_info)
-
-	# TODO: Chinese version is not working for bold.
-	def is_bold(self, char):
-		return char['fontname'] and 'bold' in char['fontname'].lower()
 
 	# TODO: Implement paragraph strategy
 	def paragraph_strategy(self, lines, subtitle_height=14):
@@ -202,28 +193,6 @@ class PdfTransformer:
 				result += "\n"
 			result += f"## {line['text']}\n"
 		elif "paragraph" in line["type"]:
-			# bold_trigger = False
-			# bold_text = ""
-			## TODO: English version is not working for set the whitespace between words.
-			## It can be solved by using extract_words() instead of extract_text_lines()
-			## TODO: Chinese version is not working for bold.
-			## It is still under investigation.
-			# for char in line["chars"]:
-				# if self.is_bold(char) and not bold_trigger: # start of bold text
-				#     bold_text += f"**{char['text']}"
-				#     bold_trigger = True
-				# elif self.is_bold(char) and bold_trigger: # continue bold text
-				#     bold_text += char["text"]
-				# elif not self.is_bold(char) and bold_trigger: # end of bold text
-				#     bold_text += f"{char['text']}**"
-				#     result += bold_text
-				#     bold_text = ""
-				#     bold_trigger = False
-				# else:
-				#     result += char["text"]
-				# result += char["text"]
-			# extract numbers from line["type"] and add a change the line when the next line is a new paragraph
-
 			result += line["text"]
 			if (
 				(i < len(lines) - 1) and

--- a/operator/document/v0/python/transformPDFToMarkdown.py
+++ b/operator/document/v0/python/transformPDFToMarkdown.py
@@ -337,7 +337,6 @@ class PdfTransformer:
 
 		return result
 
-
 	def insert_image(self, line, next_line):
 		result = ""
 		images = self.images
@@ -375,7 +374,6 @@ class PdfTransformer:
 
 		return result
 
-
 if __name__ == "__main__":
 	json_str = sys.stdin.buffer.read().decode('utf-8')
 	params = json.loads(json_str)
@@ -384,11 +382,13 @@ if __name__ == "__main__":
 	decoded_bytes = base64.b64decode(pdf_string)
 	pdf_file_obj = BytesIO(decoded_bytes)
 	pdf = PdfTransformer(pdf_file_obj, display_image_tag)
-	result = pdf.execute()
-	images = pdf.base64_images
-	output = {
-		"body": result,
-		"metadata": pdf.metadata,
-		"images": images
-	}
-	print(json.dumps(output))
+	try:
+		body = pdf.execute()
+		images = pdf.base64_images
+		output = {
+			"body": body,
+			"images": images,
+		}
+		print(json.dumps(output))
+	except Exception as e:
+		print(json.dumps({"error": str(e)}))


### PR DESCRIPTION
Because

- we do not extract images from PDF
- we do not recognise tables & LaTex in current converter

This commit

- improve pdfplumber and extract image base64
