### PR TITLE
feat(compogen): add reference to integrations on Setup block

### DIFF
--- a/ai/anthropic/v0/README.mdx
+++ b/ai/anthropic/v0/README.mdx
@@ -28,6 +28,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Anthropic, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key | `api-key` | string | Fill in your Anthropic API key. To find your keys, visit the Anthropic console page. |

--- a/ai/archetypeai/v0/README.mdx
+++ b/ai/archetypeai/v0/README.mdx
@@ -30,6 +30,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Archetype AI, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | Fill in your Archetype AI API key |

--- a/ai/cohere/v0/README.mdx
+++ b/ai/cohere/v0/README.mdx
@@ -30,6 +30,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Cohere, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key | `api-key` | string | Fill in your Cohere API key. To find your keys, visit the Cohere dashboard page. |

--- a/ai/fireworksai/v0/README.mdx
+++ b/ai/fireworksai/v0/README.mdx
@@ -29,6 +29,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Fireworks AI, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key | `api-key` | string | Fill in your Fireworks AI API key. To find your keys, visit the Fireworks AI API Keys page. |

--- a/ai/groq/v0/README.mdx
+++ b/ai/groq/v0/README.mdx
@@ -28,6 +28,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Groq, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key | `api-key` | string | Fill in your GroqCloud API key. To find your keys, visit the GroqCloud API Keys page. |

--- a/ai/huggingface/v0/README.mdx
+++ b/ai/huggingface/v0/README.mdx
@@ -44,6 +44,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Hugging Face, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | Fill in your Hugging face API token. To find your token, visit <a href="https://huggingface.co/settings/tokens">here</a> |

--- a/ai/mistralai/v0/README.mdx
+++ b/ai/mistralai/v0/README.mdx
@@ -29,6 +29,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Mistral AI, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key | `api-key` | string | Fill in your Mistral API key. To find your keys, visit the Mistral AI platform page. |

--- a/ai/ollama/v0/README.mdx
+++ b/ai/ollama/v0/README.mdx
@@ -29,6 +29,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Ollama, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Endpoint (required) | `endpoint` | string | Fill in your Ollama hosting endpoint. ### WARNING ###: As of 2024-07-26, the Ollama component does not support authentication methods. To prevent unauthorized access to your Ollama serving resources, please implement additional security measures such as IP whitelisting. |

--- a/ai/openai/v0/README.mdx
+++ b/ai/openai/v0/README.mdx
@@ -32,6 +32,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with OpenAI, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key | `api-key` | string | Fill in your OpenAI API key. To find your keys, visit your OpenAI's API Keys page. |

--- a/ai/stabilityai/v0/README.mdx
+++ b/ai/stabilityai/v0/README.mdx
@@ -29,6 +29,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Stability AI, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key | `api-key` | string | Fill in your Stability AI API key. To find your keys, visit <a href="https://platform.stability.ai/account/keys">here</a> |

--- a/application/asana/v0/README.mdx
+++ b/application/asana/v0/README.mdx
@@ -31,6 +31,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Asana, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Token (required) | `token` | string | Fill in your Asana Personal Access Token (PAT). You can generate one from <a href="https://app.asana.com/0/my-apps">developer console</a> |

--- a/application/asana/v0/config/definition.json
+++ b/application/asana/v0/config/definition.json
@@ -10,6 +10,7 @@
   "id": "asana",
   "public": true,
   "title": "Asana",
+  "vendor": "Asana",
   "description": "Do anything available on Asana",
   "tombstone": false,
   "type": "COMPONENT_TYPE_APPLICATION",

--- a/application/email/v0/README.mdx
+++ b/application/email/v0/README.mdx
@@ -31,6 +31,16 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with the
+external application, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Server Address (required) | `server-address` | string | The address of the email server |

--- a/application/email/v0/config/definition.json
+++ b/application/email/v0/config/definition.json
@@ -12,8 +12,6 @@
   "tombstone": false,
   "type": "COMPONENT_TYPE_APPLICATION",
   "uid": "ee8edff7-443f-459d-8db1-a99ea71db233",
-  "vendor": "Mail Protocol",
-  "vendorAttributes": {},
   "version": "0.1.0",
   "sourceUrl": "https://github.com/instill-ai/component/blob/main/application/email/v0",
   "releaseStage": "RELEASE_STAGE_ALPHA"

--- a/application/freshdesk/v0/README.mdx
+++ b/application/freshdesk/v0/README.mdx
@@ -42,6 +42,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Freshdesk, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API key (required) | `api-key` | string | Fill in your Freshdesk API key. To find your key, go to profile settigs and on the right pane, you can get your key once you have completed the captcha verification. |

--- a/application/github/v0/README.mdx
+++ b/application/github/v0/README.mdx
@@ -36,6 +36,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with GitHub, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Token | `token` | string | Fill in your GitHub access token for advanced usages. For more information about how to create tokens, please refer to the <a href="https://github.com/settings/tokens">github settings</a>. |

--- a/application/github/v0/config/definition.json
+++ b/application/github/v0/config/definition.json
@@ -15,6 +15,7 @@
   "id": "github",
   "public": true,
   "title": "GitHub",
+  "vendor": "GitHub",
   "description": "Do anything available on GitHub",
   "tombstone": false,
   "type": "COMPONENT_TYPE_APPLICATION",

--- a/application/googlesearch/v0/README.mdx
+++ b/application/googlesearch/v0/README.mdx
@@ -28,6 +28,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Google, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | API Key for the Google Custom Search API. You can create one <a href="https://developers.google.com/custom-search/v1/overview#api-key">here</a> |

--- a/application/hubspot/v0/README.mdx
+++ b/application/hubspot/v0/README.mdx
@@ -42,6 +42,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with HubSpot, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Token (required) | `token` | string | Fill in your HubSpot private app access token. Go here for [more information](https://developers.hubspot.com/docs/api/private-apps) |

--- a/application/jira/v0/README.mdx
+++ b/application/jira/v0/README.mdx
@@ -36,6 +36,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Atlassian, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Token (required) | `token` | string | Fill in your Jira API token. You can generate one from your Jira account "settings > security > API tokens". |

--- a/application/jira/v0/config/definition.json
+++ b/application/jira/v0/config/definition.json
@@ -15,6 +15,7 @@
   "id": "jira",
   "public": true,
   "title": "Jira",
+  "vendor": "Atlassian",
   "description": "Do anything available on Jira",
   "tombstone": false,
   "type": "COMPONENT_TYPE_APPLICATION",

--- a/application/numbers/v0/README.mdx
+++ b/application/numbers/v0/README.mdx
@@ -28,6 +28,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Numbers Protocol, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Capture token (required) | `capture-token` | string | Fill in your Capture token in the Capture App. To access your tokens, you need a Capture App account and you can sign in with email or wallet to acquire the Capture Token. |

--- a/application/slack/v0/README.mdx
+++ b/application/slack/v0/README.mdx
@@ -29,6 +29,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Slack, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Token (required) | `token` | string | Fill in your Slack app access token. For more information about how to access to create app tokens, please refer to the Slack API documentation. |

--- a/application/whatsapp/v0/README.mdx
+++ b/application/whatsapp/v0/README.mdx
@@ -36,6 +36,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with WhatsApp, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Token (required) | `token` | string | Fill in your WhatsApp access token. Go here for more information: https://developers.facebook.com/docs/whatsapp/cloud-api/get-started |

--- a/data/bigquery/v0/README.mdx
+++ b/data/bigquery/v0/README.mdx
@@ -29,6 +29,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Google, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | JSON Key File contents (required) | `json-key` | string | Contents of the JSON key file with access to the bucket. |

--- a/data/chroma/v0/README.mdx
+++ b/data/chroma/v0/README.mdx
@@ -33,6 +33,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Chroma, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | Fill in your Chroma API key |

--- a/data/elasticsearch/v0/README.mdx
+++ b/data/elasticsearch/v0/README.mdx
@@ -35,6 +35,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Elastic, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Cloud ID (required) | `cloud-id` | string | Fill in the Cloud ID for the Elasticsearch instance |

--- a/data/googlecloudstorage/v0/README.mdx
+++ b/data/googlecloudstorage/v0/README.mdx
@@ -30,6 +30,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Google, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | JSON Key File contents (required) | `json-key` | string | Contents of the JSON key file with access to the bucket. |

--- a/data/milvus/v0/README.mdx
+++ b/data/milvus/v0/README.mdx
@@ -37,6 +37,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Milvus, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Milvus URL Endpoint (required) | `url` | string | Fill in your Milvus public URL endpoint with port number, e.g http://3.25.202.142:19530 |

--- a/data/mongodb/v0/README.mdx
+++ b/data/mongodb/v0/README.mdx
@@ -37,6 +37,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with MongoDB, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | URI (required) | `uri` | string | Fill in your MongoDB URI |

--- a/data/pinecone/v0/README.mdx
+++ b/data/pinecone/v0/README.mdx
@@ -29,6 +29,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Pinecone, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | Fill in your Pinecone AI API key. You can create an api key in Pinecone Console |

--- a/data/qdrant/v0/README.mdx
+++ b/data/qdrant/v0/README.mdx
@@ -33,6 +33,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Qdrant, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | Fill in your Qdrant API key. Please refer to clusters in Qdrant data access control |

--- a/data/redis/v0/README.mdx
+++ b/data/redis/v0/README.mdx
@@ -30,6 +30,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Redis Labs, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Host (required) | `host` | string | Redis host to connect to |

--- a/data/sql/v0/README.mdx
+++ b/data/sql/v0/README.mdx
@@ -34,6 +34,16 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with the
+external application, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Engine (required) | `engine` | string | Choose the engine of your database |

--- a/data/weaviate/v0/README.mdx
+++ b/data/weaviate/v0/README.mdx
@@ -33,6 +33,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Weaviate, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | API Key (required) | `api-key` | string | Fill in your Weaviate API key. Please refer to clusters in Weaviate Console |

--- a/data/zilliz/v0/README.mdx
+++ b/data/zilliz/v0/README.mdx
@@ -35,6 +35,15 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with Zilliz, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Zilliz URL Endpoint (required) | `url` | string | Fill in your Zilliz public URL endpoint |

--- a/generic/restapi/v0/README.mdx
+++ b/generic/restapi/v0/README.mdx
@@ -34,6 +34,16 @@ The component configuration is defined and maintained [here](https://github.com/
 ## Setup
 
 
+
+
+In order to communicate with the
+external application, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
 | Authentication (required) | `authentication` | object | Authentication method to use for the REST API |

--- a/tools/compogen/cmd/testdata/readme-connector.txt
+++ b/tools/compogen/cmd/testdata/readme-connector.txt
@@ -21,6 +21,7 @@ cmp pkg/dummy/README.mdx want-readme.mdx
   "public": true,
   "id": "dummy",
   "title": "Dummy",
+  "vendor": "Dummy Inc.",
   "description": "Perform an action",
   "prerequisites": "An account at [dummy.io](https://dummy.io) is required.",
   "type": "COMPONENT_TYPE_DATA",
@@ -116,6 +117,15 @@ The component configuration is defined and maintained [here](https://github.com/
 
 <InfoBlock type="info" title="Prerequisites">An account at [dummy.io](https://dummy.io) is required.</InfoBlock>
 
+
+
+
+In order to communicate with Dummy Inc., the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |

--- a/tools/compogen/pkg/gen/definition.go
+++ b/tools/compogen/pkg/gen/definition.go
@@ -42,4 +42,5 @@ type definition struct {
 	Public        bool   `json:"public"`
 	Type          string `json:"type"`
 	Prerequisites string `json:"prerequisites"`
+	Vendor        string `json:"vendor"`
 }

--- a/tools/compogen/pkg/gen/readme.go
+++ b/tools/compogen/pkg/gen/readme.go
@@ -223,6 +223,7 @@ type readmeParams struct {
 	ID            string
 	Title         string
 	Description   string
+	Vendor        string
 	IsDraft       bool
 	ComponentType ComponentType
 	ReleaseStage  releaseStage
@@ -244,6 +245,7 @@ func (p readmeParams) parseDefinition(d definition, s *objectSchema, tasks map[s
 
 	p.ID = d.ID
 	p.Title = d.Title
+	p.Vendor = d.Vendor
 	p.Description = d.Description
 	p.IsDraft = !d.Public
 	p.ReleaseStage = d.ReleaseStage

--- a/tools/compogen/pkg/gen/resources/templates/readme.mdx.tmpl
+++ b/tools/compogen/pkg/gen/resources/templates/readme.mdx.tmpl
@@ -29,7 +29,17 @@ The component configuration is defined and maintained [here]({{ .SourceURL }}/co
 {{ with .SetupConfig.Prerequisites}}
 <InfoBlock type="info" title="Prerequisites">{{ . }}</InfoBlock>
 {{ end }}
+{{ $vendor := .Vendor }}
 {{ with .SetupConfig.Properties }}
+
+In order to communicate with {{ if $vendor }}{{ $vendor }}{{ else }}the
+external application{{ end }}, the following connection details need to be
+provided. You may specify them directly in a pipeline recipe as key-value pairs
+withing the component's `setup` block, or you can create a **Connection** from
+the [**Integration Settings**](https://www.instill.tech/docs/vdp/integration)
+page and reference the whole `setup` as `setup:
+${connection.<my-connection-id>}`.
+
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |{{ range . }}
 | {{ .Title }}{{ if .Required }} (required){{ end }} | `{{ .ID }}` | {{ .Type }} | {{ .Description }} |{{ end }}


### PR DESCRIPTION
Because

- Component setup can be now written directly in the recipe or as a reference to a Connection.

This commit

- Documents how to set up a component on its README doc.
