### PR TITLE
chore(openai): add retry for OpenAI request

### DIFF
--- a/ai/openai/v0/main.go
+++ b/ai/openai/v0/main.go
@@ -31,6 +31,7 @@ const (
 
 	cfgAPIKey       = "api-key"
 	cfgOrganization = "organization"
+	retryCount      = 3
 )
 
 var (
@@ -513,6 +514,7 @@ func (e *execution) worker(ctx context.Context, client *httpclient.Client, job *
 func (e *execution) Execute(ctx context.Context, jobs []*base.Job) error {
 
 	client := newClient(e.Setup, e.GetLogger())
+	client.SetRetryCount(retryCount)
 
 	// TODO: we can encapsulate this code into a `ConcurrentExecutor`.
 	// The `ConcurrentExecutor` will use goroutines to execute jobs in parallel.


### PR DESCRIPTION
Because

- Occasional unexpected EOF errors from OpenAI.

This commit

- Adds a retry mechanism for OpenAI requests.
