### PR TITLE
chore(web): update doc for static content scraper

### DIFF
--- a/operator/web/v0/README.mdx
+++ b/operator/web/v0/README.mdx
@@ -93,7 +93,7 @@ Scrape the webpage contents and manipulate html with jquery command. The sequenc
 | Only Main Content | `only-main-content` | boolean | Only return the main content of the page excluding header, nav, footer. |
 | Remove Tags | `remove-tags` | array[string] | A list of tags, classes, and ids to remove from the output. If empty, no tags will be removed. Example: 'script, .ad, #footer' |
 | Only Include Tags | `only-include-tags` | array[string] | A list of tags, classes, and ids to include in the output. If empty, all tags will be included. Example: 'script, .ad, #footer' |
-| Timeout | `timeout` | integer | The time to wait for the page to load in milliseconds. Min 0, Max 60000. |
+| Timeout | `timeout` | integer | The time to wait for the page to load in milliseconds. Min 0, Max 60000. Please set it as 0 if you only want to collect static content. |
 
 
 

--- a/operator/web/v0/config/tasks.json
+++ b/operator/web/v0/config/tasks.json
@@ -368,7 +368,7 @@
         },
         "timeout": {
           "default": 1000,
-          "description": "The time to wait for the page to load in milliseconds. Min 0, Max 60000.",
+          "description": "The time to wait for the page to load in milliseconds. Min 0, Max 60000. Please set it as 0 if you only want to collect static content.",
           "instillAcceptFormats": [
             "integer"
           ],


### PR DESCRIPTION
Because

- scraper for dynamic content sometimes failed

This commit

- add static scraper in the doc for the users who do not need the dynamic content
