### PR TITLE
fix(document): fix jpg conversion bug

### DIFF
--- a/operator/document/v0/convert_test.go
+++ b/operator/document/v0/convert_test.go
@@ -45,10 +45,10 @@ func TestConvertToText(t *testing.T) {
 			name:     "Convert png file",
 			filepath: "testdata/test.png",
 		},
-		// {
-		// 	name:     "Convert jpg file",
-		// 	filepath: "testdata/test.jpg",
-		// },
+		{
+			name:     "Convert jpg file",
+			filepath: "testdata/test.jpg",
+		},
 		{
 			name:     "Convert tiff file",
 			filepath: "testdata/test.tif",


### PR DESCRIPTION
Because

- there is a bug when using docconv when converting jpg

This commit

- fix the bug with jpg -> png -> text
