### PR TITLE
fix(document): fix the bug from pdfplumber

### DIFF
--- a/operator/document/v0/config/tasks.json
+++ b/operator/document/v0/config/tasks.json
@@ -80,6 +80,13 @@
           },
           "title": "Images",
           "type": "array"
+        },
+        "error": {
+          "description": "Error message if any during the conversion process",
+          "instillFormat": "string",
+          "instillUIOrder": 3,
+          "title": "Error",
+          "type": "string"
         }
       },
       "required": [

--- a/operator/document/v0/convert_document_to_markdown.go
+++ b/operator/document/v0/convert_document_to_markdown.go
@@ -19,6 +19,7 @@ type ConvertDocumentToMarkdownOutput struct {
 	Body     string   `json:"body"`
 	Filename string   `json:"filename"`
 	Images   []string `json:"images,omitempty"`
+	Error    string   `json:"error,omitempty"`
 }
 
 func ConvertDocumentToMarkdown(inputStruct *ConvertDocumentToMarkdownInput, transformerGetter MarkdownTransformerGetterFunc) (*ConvertDocumentToMarkdownOutput, error) {
@@ -47,6 +48,7 @@ func ConvertDocumentToMarkdown(inputStruct *ConvertDocumentToMarkdownInput, tran
 	outputStruct := &ConvertDocumentToMarkdownOutput{
 		Body:   converterOutput.Body,
 		Images: converterOutput.Images,
+		Error:  converterOutput.Error,
 	}
 
 	if inputStruct.Filename != "" {

--- a/operator/document/v0/convert_document_to_markdown.go
+++ b/operator/document/v0/convert_document_to_markdown.go
@@ -48,7 +48,7 @@ func ConvertDocumentToMarkdown(inputStruct *ConvertDocumentToMarkdownInput, tran
 	outputStruct := &ConvertDocumentToMarkdownOutput{
 		Body:   converterOutput.Body,
 		Images: converterOutput.Images,
-		Error:  converterOutput.Error,
+		Error:  strings.Join(converterOutput.Error, "\n"),
 	}
 
 	if inputStruct.Filename != "" {

--- a/operator/document/v0/pdf_to_markdown_converter.go
+++ b/operator/document/v0/pdf_to_markdown_converter.go
@@ -54,8 +54,8 @@ func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool)
 	}
 
 	err = json.Unmarshal(outputBytes, &output)
-	if err != nil || output.Error != "" {
-		return output, fmt.Errorf("failed to unmarshal output: %w, %s", err, output.Error)
+	if err != nil {
+		return output, fmt.Errorf("failed to unmarshal output: %w", err)
 	}
 
 	return output, nil

--- a/operator/document/v0/pdf_to_markdown_converter.go
+++ b/operator/document/v0/pdf_to_markdown_converter.go
@@ -11,7 +11,7 @@ import (
 type converterOutput struct {
 	Body   string   `json:"body"`
 	Images []string `json:"images"`
-	Error  string   `json:"error"`
+	Error  []string `json:"error"`
 }
 
 func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool) (converterOutput, error) {


### PR DESCRIPTION
Because

- pdfplumber read the images with the wrong position

This commit

- catch the error if the position is wrong
