### PR TITLE
fix(instillartifact): fix bugs

### DIFF
--- a/data/instillartifact/v0/main_test.go
+++ b/data/instillartifact/v0/main_test.go
@@ -70,6 +70,16 @@ func Test_uploadFile(t *testing.T) {
 
 			clientMock := mock.NewArtifactPublicServiceClientMock(mc)
 			if tc.option == "create new catalog" {
+				clientMock.ListCatalogsMock.
+					Times(1).
+					Expect(minimock.AnyContext,
+						&artifactPB.ListCatalogsRequest{
+							NamespaceId: "fakeNs",
+						},
+					).Return(&artifactPB.ListCatalogsResponse{
+					Catalogs: []*artifactPB.Catalog{},
+				}, nil)
+
 				clientMock.
 					CreateCatalogMock.
 					Times(1).


### PR DESCRIPTION
Because

- we did not fetch next page tokens when the file count is more than a page
- the previous upload file design is not good because it catches the error by error message, which is not robust

This commit

- fetch next page tokens
- list all catalogs first and create a new one if there isn't existing
