### PR TITLE
chore(collection): rename `TASK_DECLARE` to `TASK_ASSIGN`

### DIFF
--- a/generic/collection/v0/README.mdx
+++ b/generic/collection/v0/README.mdx
@@ -8,7 +8,7 @@ description: "Learn about how to set up a VDP Collection component https://githu
 The Collection component is a generic component that allows users to manipulate collection-type data.
 It can carry out the following tasks:
 
-- [Declare](#declare)
+- [Assign](#assign)
 - [Append Array](#append-array)
 
 
@@ -31,15 +31,15 @@ The component configuration is defined and maintained [here](https://github.com/
 
 ## Supported Tasks
 
-### Declare
+### Assign
 
-Set the data.
+Assign the data.
 
 
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Task ID (required) | `task` | string | `TASK_DECLARE` |
-| Data (required) | `data` | any | Specify the data you want to set. |
+| Task ID (required) | `task` | string | `TASK_ASSIGN` |
+| Data (required) | `data` | any | Specify the data you want to assign. |
 
 
 
@@ -51,7 +51,7 @@ Set the data.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The data you set. |
+| Data | `data` | any | The data you assign. |
 
 
 

--- a/generic/collection/v0/config/definition.json
+++ b/generic/collection/v0/config/definition.json
@@ -1,6 +1,6 @@
 {
   "availableTasks": [
-    "TASK_DECLARE",
+    "TASK_ASSIGN",
     "TASK_APPEND_ARRAY"
   ],
   "custom": false,

--- a/generic/collection/v0/config/tasks.json
+++ b/generic/collection/v0/config/tasks.json
@@ -1,6 +1,6 @@
 {
-  "TASK_DECLARE": {
-    "instillShortDescription": "Set the data.",
+  "TASK_ASSIGN": {
+    "instillShortDescription": "Assign the data.",
     "input": {
       "description": "Input",
       "instillEditOnNodeFields": [
@@ -9,7 +9,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
-          "description": "Specify the data you want to set.",
+          "description": "Specify the data you want to assign.",
           "instillAcceptFormats": [
             "*"
           ],
@@ -38,7 +38,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
-          "description": "The data you set.",
+          "description": "The data you assign.",
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
           "instillUIOrder": 0,

--- a/generic/collection/v0/main.go
+++ b/generic/collection/v0/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	taskDeclare     = "TASK_DECLARE"
+	taskAssign      = "TASK_ASSIGN"
 	taskAppendArray = "TASK_APPEND_ARRAY"
 )
 
@@ -57,8 +57,8 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 	e := &execution{ComponentExecution: x}
 
 	switch x.Task {
-	case taskDeclare:
-		e.execute = e.declare
+	case taskAssign:
+		e.execute = e.assign
 	case taskAppendArray:
 		e.execute = e.appendArray
 	default:
@@ -70,7 +70,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 	return e, nil
 }
 
-func (e *execution) declare(in *structpb.Struct) (*structpb.Struct, error) {
+func (e *execution) assign(in *structpb.Struct) (*structpb.Struct, error) {
 	out := in
 	return out, nil
 }


### PR DESCRIPTION
Because

- The `TASK_ASSIGN` is a better naming for `TASK_DECLARE`

This commit

- Updates the task name.
