### PR TITLE
feat(collection): introduce TASK_UNION, TASK_INTERSECTION and TASK_DIFFERENCE

### DIFF
--- a/ai/universalai/v0/README.mdx
+++ b/ai/universalai/v0/README.mdx
@@ -51,18 +51,6 @@ Generate response base on conversation input
 <details>
 <summary> Input Objects in Chat</summary>
 
-<h4 id="chat-input-parameter">Input Parameter</h4>
-
-Input parameter
-
-| Field | Field ID | Type | Note |
-| :--- | :--- | :--- | :--- |
-| Max new tokens | `max-tokens` | integer | The maximum number of tokens for model to generate  |
-| Number of choices | `n` | integer | How many chat completion choices to generate for each input message.  |
-| Seed | `seed` | integer | The seed, default is 0  |
-| Stream | `stream` | boolean | If set, partial message deltas will be sent. Tokens will be sent as data-only server-sent events as they become available.  |
-| Temperature | `temperature` | number | The temperature for sampling  |
-| Top P | `top-p` | number | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.  |
 <h4 id="chat-chat-data">Chat Data</h4>
 
 Input data
@@ -80,6 +68,18 @@ List of chat messages
 | [Content](#chat-content) | `content` | array | The message content  |
 | Name | `name` | string | An optional name for the participant. Provides the model information to differentiate between participants of the same role.  |
 | Role | `role` | string | The message role, i.e. 'system', 'user' or 'assistant'  <br/><details><summary><strong>Enum values</strong></summary><ul><li>`system`</li><li>`user`</li><li>`assistant`</li></ul></details>  |
+<h4 id="chat-input-parameter">Input Parameter</h4>
+
+Input parameter
+
+| Field | Field ID | Type | Note |
+| :--- | :--- | :--- | :--- |
+| Max new tokens | `max-tokens` | integer | The maximum number of tokens for model to generate  |
+| Number of choices | `n` | integer | How many chat completion choices to generate for each input message.  |
+| Seed | `seed` | integer | The seed, default is 0  |
+| Stream | `stream` | boolean | If set, partial message deltas will be sent. Tokens will be sent as data-only server-sent events as they become available.  |
+| Temperature | `temperature` | number | The temperature for sampling  |
+| Top P | `top-p` | number | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.  |
 </details>
 
 

--- a/generic/collection/v0/README.mdx
+++ b/generic/collection/v0/README.mdx
@@ -9,6 +9,9 @@ The Collection component is a generic component that allows users to manipulate 
 It can carry out the following tasks:
 - [Assign](#assign)
 - [Append Array](#append-array)
+- [Union](#union)
+- [Intersection](#intersection)
+- [Difference](#difference)
 
 ## Release Stage
 
@@ -56,3 +59,55 @@ Add data to the end of an array.
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Array | `array` | array | A updated array with the specified data appended to the end of it. |
+
+### Union
+
+Find the union of the sets
+
+| Input | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Task ID (required) | `task` | string | `TASK_UNION` |
+| Array (required) | `sets` | array | Specify the sets you want to union. |
+
+
+
+
+
+| Output | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Array | `set` | array | The union set. |
+
+### Intersection
+
+Find the intersection of the sets
+
+| Input | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Task ID (required) | `task` | string | `TASK_INTERSECTION` |
+| Array (required) | `sets` | array | Specify the sets you want to intersect. |
+
+
+
+
+
+| Output | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Array | `set` | array | The intersection set. |
+
+### Difference
+
+Find the difference between the two sets, i.e. `set-a` \ `set-b`, identifying the elements that are in `set-a` but not in `set-b`.
+
+| Input | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Task ID (required) | `task` | string | `TASK_DIFFERENCE` |
+| Array (required) | `set-a` | array | Specify the set-a. |
+| Array (required) | `set-b` | array | Specify the set-b. |
+
+
+
+
+
+| Output | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Array | `set` | array | The difference set. |

--- a/generic/collection/v0/config/definition.json
+++ b/generic/collection/v0/config/definition.json
@@ -1,7 +1,10 @@
 {
   "availableTasks": [
     "TASK_ASSIGN",
-    "TASK_APPEND_ARRAY"
+    "TASK_APPEND_ARRAY",
+    "TASK_UNION",
+    "TASK_INTERSECTION",
+    "TASK_DIFFERENCE"
   ],
   "custom": false,
   "documentationUrl": "https://www.instill.tech/docs/component/generic/collection",

--- a/generic/collection/v0/config/tasks.json
+++ b/generic/collection/v0/config/tasks.json
@@ -126,5 +126,195 @@
       "title": "Output",
       "type": "object"
     }
+  },
+  "TASK_UNION": {
+    "instillShortDescription": "Find the union of the sets",
+    "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "sets"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "sets": {
+          "description": "Specify the sets you want to union.",
+          "instillAcceptFormats": [
+            "array:array:*"
+          ],
+          "instillUIMultiline": true,
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "items": {},
+          "required": [],
+          "title": "Array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "sets"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "set"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "set": {
+          "description": "The union set.",
+          "instillEditOnNodeFields": [],
+          "instillFormat": "array:*",
+          "instillUIOrder": 0,
+          "required": [],
+          "title": "Array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "set"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_INTERSECTION": {
+    "instillShortDescription": "Find the intersection of the sets",
+    "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "sets"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "sets": {
+          "description": "Specify the sets you want to intersect.",
+          "instillAcceptFormats": [
+            "array:array:*"
+          ],
+          "instillUIMultiline": true,
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "items": {},
+          "required": [],
+          "title": "Array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "sets"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "set"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "set": {
+          "description": "The intersection set.",
+          "instillEditOnNodeFields": [],
+          "instillFormat": "array:*",
+          "instillUIOrder": 0,
+          "required": [],
+          "title": "Array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "set"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_DIFFERENCE": {
+    "instillShortDescription": "Find the difference between the two sets, i.e. `set-a` \\ `set-b`, identifying the elements that are in `set-a` but not in `set-b`.",
+    "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "set-a",
+        "set-b"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "set-a": {
+          "description": "Specify the set-a.",
+          "instillAcceptFormats": [
+            "array:*"
+          ],
+          "instillUIMultiline": true,
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "items": {},
+          "required": [],
+          "title": "Array",
+          "type": "array"
+        },
+        "set-b": {
+          "description": "Specify the set-b.",
+          "instillAcceptFormats": [
+            "array:*"
+          ],
+          "instillUIMultiline": true,
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "items": {},
+          "required": [],
+          "title": "Array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "set-a",
+        "set-b"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "set"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "set": {
+          "description": "The difference set.",
+          "instillEditOnNodeFields": [],
+          "instillFormat": "array:*",
+          "instillUIOrder": 0,
+          "required": [],
+          "title": "Array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "set"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
   }
 }

--- a/generic/collection/v0/main.go
+++ b/generic/collection/v0/main.go
@@ -3,11 +3,14 @@ package collection
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 
 	_ "embed"
 
+	"github.com/samber/lo"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/base"
@@ -15,8 +18,11 @@ import (
 )
 
 const (
-	taskAssign      = "TASK_ASSIGN"
-	taskAppendArray = "TASK_APPEND_ARRAY"
+	taskAssign       = "TASK_ASSIGN"
+	taskUnion        = "TASK_UNION"
+	taskIntersection = "TASK_INTERSECTION"
+	taskDifference   = "TASK_DIFFERENCE"
+	taskAppendArray  = "TASK_APPEND_ARRAY"
 )
 
 var (
@@ -59,6 +65,12 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 	switch x.Task {
 	case taskAssign:
 		e.execute = e.assign
+	case taskUnion:
+		e.execute = e.union
+	case taskIntersection:
+		e.execute = e.intersection
+	case taskDifference:
+		e.execute = e.difference
 	case taskAppendArray:
 		e.execute = e.appendArray
 	default:
@@ -68,6 +80,139 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 		)
 	}
 	return e, nil
+}
+
+func (e *execution) union(in *structpb.Struct) (*structpb.Struct, error) {
+	sets := in.Fields["sets"].GetListValue().Values
+	cache := [][]string{}
+
+	for _, s := range sets {
+		c := []string{}
+		for _, v := range s.GetListValue().Values {
+			b, err := protojson.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			c = append(c, string(b))
+		}
+		cache = append(cache, c)
+	}
+
+	set := &structpb.ListValue{Values: []*structpb.Value{}}
+	un := lo.Union(cache...)
+	for _, u := range un {
+		var a any
+		err := json.Unmarshal([]byte(u), &a)
+		if err != nil {
+			return nil, err
+		}
+		v, err := structpb.NewValue(a)
+		if err != nil {
+			return nil, err
+		}
+		set.Values = append(set.Values, v)
+	}
+
+	out := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+	out.Fields["set"] = structpb.NewListValue(set)
+	return out, nil
+}
+
+func (e *execution) intersection(in *structpb.Struct) (*structpb.Struct, error) {
+	sets := in.Fields["sets"].GetListValue().Values
+
+	if len(sets) == 1 {
+		out := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+		out.Fields["set"] = structpb.NewListValue(sets[0].GetListValue())
+		return out, nil
+	}
+
+	curr := make([]string, len(sets[0].GetListValue().Values))
+	for idx, v := range sets[0].GetListValue().Values {
+		b, err := protojson.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		curr[idx] = string(b)
+	}
+
+	for _, s := range sets[1:] {
+		next := make([]string, len(s.GetListValue().Values))
+		for idx, v := range s.GetListValue().Values {
+			b, err := protojson.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			next[idx] = string(b)
+		}
+
+		i := lo.Intersect(curr, next)
+		curr = i
+
+	}
+
+	set := &structpb.ListValue{Values: make([]*structpb.Value, len(curr))}
+
+	for idx, c := range curr {
+		var a any
+		err := json.Unmarshal([]byte(c), &a)
+		if err != nil {
+			return nil, err
+		}
+		v, err := structpb.NewValue(a)
+		if err != nil {
+			return nil, err
+		}
+		set.Values[idx] = v
+	}
+
+	out := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+	out.Fields["set"] = structpb.NewListValue(set)
+	return out, nil
+}
+
+func (e *execution) difference(in *structpb.Struct) (*structpb.Struct, error) {
+	setA := in.Fields["set-a"]
+	setB := in.Fields["set-b"]
+
+	valuesA := make([]string, len(setA.GetListValue().Values))
+	for idx, v := range setA.GetListValue().Values {
+		b, err := protojson.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		valuesA[idx] = string(b)
+	}
+
+	valuesB := make([]string, len(setB.GetListValue().Values))
+	for idx, v := range setB.GetListValue().Values {
+		b, err := protojson.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		valuesB[idx] = string(b)
+	}
+	dif, _ := lo.Difference(valuesA, valuesB)
+
+	set := &structpb.ListValue{Values: make([]*structpb.Value, len(dif))}
+
+	for idx, c := range dif {
+		var a any
+
+		err := json.Unmarshal([]byte(c), &a)
+		if err != nil {
+			return nil, err
+		}
+		v, err := structpb.NewValue(a)
+		if err != nil {
+			return nil, err
+		}
+		set.Values[idx] = v
+	}
+
+	out := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+	out.Fields["set"] = structpb.NewListValue(set)
+	return out, nil
 }
 
 func (e *execution) assign(in *structpb.Struct) (*structpb.Struct, error) {

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/redis/go-redis/v9 v9.5.1
+	github.com/samber/lo v1.47.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/slack-go/slack v0.12.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -452,6 +452,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7AwssoOcM/tq5JjjG2yYOc8odClEiXA=
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=


### PR DESCRIPTION
Because

- We want to provide set operations.

This commit

- Introduces new set operations: `TASK_UNION`, `TASK_INTERSECTION`, and `TASK_DIFFERENCE`.