### PR TITLE
chore(all): format and lint yaml

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,3 +1,4 @@
+---
 coverage:
   status:
     project:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,3 @@
+---
 instill component:
   - "**"

--- a/.github/workflows/add-label-to-pr.yml
+++ b/.github/workflows/add-label-to-pr.yml
@@ -1,3 +1,4 @@
+---
 name: Add Label to PR
 
 on:

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -1,3 +1,4 @@
+---
 name: Add PR to Project
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,4 @@
+---
 name: Code Scanning
 
 on:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,4 @@
+---
 name: Coverage
 
 on: [push, pull_request]

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,3 +1,4 @@
+---
 name: golangci-lint
 
 on:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,3 +1,4 @@
+---
 name: Release Please
 
 on:

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,3 +1,4 @@
+---
 name: "Lint PR"
 
 on:

--- a/.github/workflows/test-compogen.yml
+++ b/.github/workflows/test-compogen.yml
@@ -1,3 +1,4 @@
+---
 name: Compogen test
 
 on:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,8 @@
+---
 linters:
   enable:
     - stylecheck
 
 linters-settings:
   stylecheck:
-    checks: [ "all" ]
+    checks: [all]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -31,3 +32,8 @@ repos:
         entry: bash -c 'make gen-doc'
         language: system
         files: \.(json|mdx)$
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
+        args: [--mapping, "2", --sequence, "4", --offset, "2", --preserve-quotes]

--- a/ai/anthropic/v0/.compogen/bottom.mdx
+++ b/ai/anthropic/v0/.compogen/bottom.mdx
@@ -5,44 +5,44 @@ Recipe for the [List GitHub Repo Issues](https://instill.tech/instill-ai/pipelin
 ```yaml
 version: v1beta
 component:
-    anthropic-0:
-        type: anthropic
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 1000
-            model-name: claude-3-5-sonnet-20240620
-            prompt: Summarise and pick the most important issues from this list ${github.output.issues}
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    github:
-        type: github
-        task: TASK_LIST_ISSUES
-        input:
-            direction: desc
-            no-pull-request: false
-            owner: ${variable.repository-owner}
-            page: 1
-            per-page: 30
-            repository: ${variable.repository-name}
-            since: "2021-01-01T00:00:00Z"
-            sort: created
-            state: open
-        setup:
-            token: ${secret.github-demo}
+  anthropic-0:
+    type: anthropic
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 1000
+      model-name: claude-3-5-sonnet-20240620
+      prompt: Summarise and pick the most important issues from this list ${github.output.issues}
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  github:
+    type: github
+    task: TASK_LIST_ISSUES
+    input:
+      direction: desc
+      no-pull-request: false
+      owner: ${variable.repository-owner}
+      page: 1
+      per-page: 30
+      repository: ${variable.repository-name}
+      since: "2021-01-01T00:00:00Z"
+      sort: created
+      state: open
+    setup:
+      token: ${secret.github-demo}
 variable:
-    repository-name:
-        title: Repository Name
-        description: Name of the repository i.e. instill-core
-        instill-format: string
-    repository-owner:
-        title: Repository Owner
-        description: Name of the repository owner i.e. instill-ai
-        instill-format: string
+  repository-name:
+    title: Repository Name
+    description: Name of the repository i.e. instill-core
+    instill-format: string
+  repository-owner:
+    title: Repository Owner
+    description: Name of the repository owner i.e. instill-ai
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${anthropic-0.output.text}
+  result:
+    title: Result
+    value: ${anthropic-0.output.text}
 ```

--- a/ai/anthropic/v0/README.mdx
+++ b/ai/anthropic/v0/README.mdx
@@ -106,44 +106,44 @@ Recipe for the [List GitHub Repo Issues](https://instill.tech/instill-ai/pipelin
 ```yaml
 version: v1beta
 component:
-    anthropic-0:
-        type: anthropic
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 1000
-            model-name: claude-3-5-sonnet-20240620
-            prompt: Summarise and pick the most important issues from this list ${github.output.issues}
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    github:
-        type: github
-        task: TASK_LIST_ISSUES
-        input:
-            direction: desc
-            no-pull-request: false
-            owner: ${variable.repository-owner}
-            page: 1
-            per-page: 30
-            repository: ${variable.repository-name}
-            since: "2021-01-01T00:00:00Z"
-            sort: created
-            state: open
-        setup:
-            token: ${secret.github-demo}
+  anthropic-0:
+    type: anthropic
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 1000
+      model-name: claude-3-5-sonnet-20240620
+      prompt: Summarise and pick the most important issues from this list ${github.output.issues}
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  github:
+    type: github
+    task: TASK_LIST_ISSUES
+    input:
+      direction: desc
+      no-pull-request: false
+      owner: ${variable.repository-owner}
+      page: 1
+      per-page: 30
+      repository: ${variable.repository-name}
+      since: "2021-01-01T00:00:00Z"
+      sort: created
+      state: open
+    setup:
+      token: ${secret.github-demo}
 variable:
-    repository-name:
-        title: Repository Name
-        description: Name of the repository i.e. instill-core
-        instill-format: string
-    repository-owner:
-        title: Repository Owner
-        description: Name of the repository owner i.e. instill-ai
-        instill-format: string
+  repository-name:
+    title: Repository Name
+    description: Name of the repository i.e. instill-core
+    instill-format: string
+  repository-owner:
+    title: Repository Owner
+    description: Name of the repository owner i.e. instill-ai
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${anthropic-0.output.text}
+  result:
+    title: Result
+    value: ${anthropic-0.output.text}
 ```

--- a/ai/fireworksai/v0/.compogen/bottom.mdx
+++ b/ai/fireworksai/v0/.compogen/bottom.mdx
@@ -5,27 +5,26 @@ Recipe for the [Fireworks Chinese Content Writer](https://instill.tech/instill-a
 ```yaml
 version: v1beta
 component:
-    fireworks-0:
-        type: fireworks-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 200
-            model: qwen2-72b-instruct
-            prompt: ${variable.prompt}
-            system-message: You are a expert social media content writing assistant. Output the result in chinese for 小紅書.
-            temperature: 0.05
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+  fireworks-0:
+    type: fireworks-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 200
+      model: qwen2-72b-instruct
+      prompt: ${variable.prompt}
+      system-message: You are a expert social media content writing assistant. Output the result in chinese for 小紅書.
+      temperature: 0.05
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    prompt:
-        title: prompt
-        description: input prompt i.e. "寫一份生椰拿鐵文案", "write about horses"
-        instill-format: string
+  prompt:
+    title: prompt
+    description: input prompt i.e. "寫一份生椰拿鐵文案", "write about horses"
+    instill-format: string
 output:
-    output:
-        title: output
-        value: ${fireworks-0.output.text}
-
+  output:
+    title: output
+    value: ${fireworks-0.output.text}
 ```

--- a/ai/fireworksai/v0/README.mdx
+++ b/ai/fireworksai/v0/README.mdx
@@ -137,27 +137,26 @@ Recipe for the [Fireworks Chinese Content Writer](https://instill.tech/instill-a
 ```yaml
 version: v1beta
 component:
-    fireworks-0:
-        type: fireworks-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 200
-            model: qwen2-72b-instruct
-            prompt: ${variable.prompt}
-            system-message: You are a expert social media content writing assistant. Output the result in chinese for 小紅書.
-            temperature: 0.05
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+  fireworks-0:
+    type: fireworks-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 200
+      model: qwen2-72b-instruct
+      prompt: ${variable.prompt}
+      system-message: You are a expert social media content writing assistant. Output the result in chinese for 小紅書.
+      temperature: 0.05
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    prompt:
-        title: prompt
-        description: input prompt i.e. "寫一份生椰拿鐵文案", "write about horses"
-        instill-format: string
+  prompt:
+    title: prompt
+    description: input prompt i.e. "寫一份生椰拿鐵文案", "write about horses"
+    instill-format: string
 output:
-    output:
-        title: output
-        value: ${fireworks-0.output.text}
-
+  output:
+    title: output
+    value: ${fireworks-0.output.text}
 ```

--- a/ai/groq/v0/.compogen/bottom.mdx
+++ b/ai/groq/v0/.compogen/bottom.mdx
@@ -5,31 +5,31 @@ Recipe for the [Groq Interview Helper](https://instill.tech/instill-ai/pipelines
 ```yaml
 version: v1beta
 component:
-    groq-0:
-        type: groq
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 300
-            model: llama3-groq-70b-8192-tool-use-preview
-            prompt: |-
-                Rewrite this experience using the STAR (Situation, Task, Action, Result) method for a resume or CV:
+  groq-0:
+    type: groq
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 300
+      model: llama3-groq-70b-8192-tool-use-preview
+      prompt: |-
+        Rewrite this experience using the STAR (Situation, Task, Action, Result) method for a resume or CV:
 
-                ${variable.experience}
-            system-message: You are a helpful resume assistant.
-            temperature: 0.05
-            top-k: 10
-            top-p: 0.5
-            user: instill-ai
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        ${variable.experience}
+      system-message: You are a helpful resume assistant.
+      temperature: 0.05
+      top-k: 10
+      top-p: 0.5
+      user: instill-ai
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    experience:
-        title: experience
-        description: describe your work experience
-        instill-format: string
-        instill-ui-multiline: true
+  experience:
+    title: experience
+    description: describe your work experience
+    instill-format: string
+    instill-ui-multiline: true
 output:
-    resume_format:
-        title: resume_format
-        value: ${groq-0.output.text}
+  resume_format:
+    title: resume_format
+    value: ${groq-0.output.text}
 ```

--- a/ai/groq/v0/README.mdx
+++ b/ai/groq/v0/README.mdx
@@ -108,31 +108,31 @@ Recipe for the [Groq Interview Helper](https://instill.tech/instill-ai/pipelines
 ```yaml
 version: v1beta
 component:
-    groq-0:
-        type: groq
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 300
-            model: llama3-groq-70b-8192-tool-use-preview
-            prompt: |-
-                Rewrite this experience using the STAR (Situation, Task, Action, Result) method for a resume or CV:
+  groq-0:
+    type: groq
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 300
+      model: llama3-groq-70b-8192-tool-use-preview
+      prompt: |-
+        Rewrite this experience using the STAR (Situation, Task, Action, Result) method for a resume or CV:
 
-                ${variable.experience}
-            system-message: You are a helpful resume assistant.
-            temperature: 0.05
-            top-k: 10
-            top-p: 0.5
-            user: instill-ai
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        ${variable.experience}
+      system-message: You are a helpful resume assistant.
+      temperature: 0.05
+      top-k: 10
+      top-p: 0.5
+      user: instill-ai
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    experience:
-        title: experience
-        description: describe your work experience
-        instill-format: string
-        instill-ui-multiline: true
+  experience:
+    title: experience
+    description: describe your work experience
+    instill-format: string
+    instill-ui-multiline: true
 output:
-    resume_format:
-        title: resume_format
-        value: ${groq-0.output.text}
+  resume_format:
+    title: resume_format
+    value: ${groq-0.output.text}
 ```

--- a/ai/mistralai/v0/.compogen/bottom.mdx
+++ b/ai/mistralai/v0/.compogen/bottom.mdx
@@ -5,72 +5,71 @@ Recipe for the [Short-film Script Writer](https://instill.tech/instill-ai/pipeli
 ```yaml
 version: v1beta
 component:
-    mistral-0:
-        type: mistral-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 1500
-            model-name: codestral-latest
-            prompt: |-
-                Generate a short-film movie script with the following placeholders:
-                [THEME]: ${variable.theme}
-                [GENRE]: ${variable.genre}
-                [NUM_ACTORS]: ${variable.num_actors}
-                [SETTING]: ${variable.setting}
-                [TIME_PERIOD]: The era or time frame of the story
-                [DURATION]: ${variable.duration}
-                [CONFLICT]: ${variable.conflict}
+  mistral-0:
+    type: mistral-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 1500
+      model-name: codestral-latest
+      prompt: |-
+        Generate a short-film movie script with the following placeholders:
+        [THEME]: ${variable.theme}
+        [GENRE]: ${variable.genre}
+        [NUM_ACTORS]: ${variable.num_actors}
+        [SETTING]: ${variable.setting}
+        [TIME_PERIOD]: The era or time frame of the story
+        [DURATION]: ${variable.duration}
+        [CONFLICT]: ${variable.conflict}
 
-                Please create a script that includes:
+        Please create a script that includes:
 
-                A brief synopsis (2-3 sentences)
-                Character descriptions for each main character
-                Scene-by-scene breakdown with dialogue and basic action descriptions
-                A conclusion that resolves the main conflict
+        A brief synopsis (2-3 sentences)
+        Character descriptions for each main character
+        Scene-by-scene breakdown with dialogue and basic action descriptions
+        A conclusion that resolves the main conflict
 
-                Ensure the script is coherent, engaging, and fits within the specified parameters. Be creative with the storytelling while maintaining the structure of a proper short film script.
-            safe: false
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        Ensure the script is coherent, engaging, and fits within the specified parameters. Be creative with the storytelling while maintaining the structure of a proper short film script.
+      safe: false
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    conflict:
-        title: Conflict
-        description: The main problem or challenge faced by the characters i.e. existential crisis
-        instill-format: string
-    duration:
-        title: Duration
-        description: Approximate length of the film in minutes i.e. 5
-        instill-format: string
-    genre:
-        title: Genre
-        description: The type of genre for this film i.e. romance, comedy, horror, action, etc.
-        instill-format: string
-    num_actors:
-        title: Num_actors
-        description: The number of actors that will be in this film i.e. 2
-        instill-format: string
-    setting:
-        title: Setting
-        description: |
-            The primary location where the story takes place i.e. Rome
-        instill-format: string
-    theme:
-        title: Theme
-        description: Insert the main theme or central idea of the film i.e. time travelling
-        instill-format: string
-    time-period:
-        title: Time Period
-        description: The era or time frame of the story i.e. stone age, 20th century, etc.
-        instill-format: string
+  conflict:
+    title: Conflict
+    description: The main problem or challenge faced by the characters i.e. existential crisis
+    instill-format: string
+  duration:
+    title: Duration
+    description: Approximate length of the film in minutes i.e. 5
+    instill-format: string
+  genre:
+    title: Genre
+    description: The type of genre for this film i.e. romance, comedy, horror, action, etc.
+    instill-format: string
+  num_actors:
+    title: Num_actors
+    description: The number of actors that will be in this film i.e. 2
+    instill-format: string
+  setting:
+    title: Setting
+    description: |
+      The primary location where the story takes place i.e. Rome
+    instill-format: string
+  theme:
+    title: Theme
+    description: Insert the main theme or central idea of the film i.e. time travelling
+    instill-format: string
+  time-period:
+    title: Time Period
+    description: The era or time frame of the story i.e. stone age, 20th century, etc.
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${mistral-0.output.text}
-
+  result:
+    title: Result
+    value: ${mistral-0.output.text}
 ```
 
 Recipe for the [PicassoAI: Cubist Creations at Your Command!](https://instill.tech/instill-ai/pipelines/picasso-ai/playground) pipeline.
@@ -78,70 +77,70 @@ Recipe for the [PicassoAI: Cubist Creations at Your Command!](https://instill.te
 ```yaml
 version: v1beta
 component:
-    mistral-0:
-        type: mistral-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 100
-            model-name: open-mixtral-8x22b
-            prompt: |-
-                Generate a Picasso-inspired image based on the following user input:
+  mistral-0:
+    type: mistral-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 100
+      model-name: open-mixtral-8x22b
+      prompt: |-
+        Generate a Picasso-inspired image based on the following user input:
 
-                ${variable.prompt}
+        ${variable.prompt}
 
-                Using the specified Picasso period: ${variable.period}
+        Using the specified Picasso period: ${variable.period}
 
 
-                Transform this input into a detailed text-to-image prompt by:
+        Transform this input into a detailed text-to-image prompt by:
 
-                1. Identifying the key elements or subjects in the user's description
+        1. Identifying the key elements or subjects in the user's description
 
-                2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
+        2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
 
-                3. Including cubist or abstract features characteristic of the ${variable.period}
+        3. Including cubist or abstract features characteristic of the ${variable.period}
 
-                4. Suggesting a composition or scene layout typical of Picasso's work from this era
+        4. Suggesting a composition or scene layout typical of Picasso's work from this era
 
-                Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
-            safe: false
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_TO_IMAGE
-        input:
-            model: dall-e-3
-            n: 1
-            prompt: |-
-                Using this primary color palette: ${variable.colour}
+        Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
+      safe: false
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_TO_IMAGE
+    input:
+      model: dall-e-3
+      n: 1
+      prompt: |-
+        Using this primary color palette: ${variable.colour}
 
-                ${mistral-0.output.text}
-            quality: standard
-            size: 1024x1024
-            style: vivid
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        ${mistral-0.output.text}
+      quality: standard
+      size: 1024x1024
+      style: vivid
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    colour:
-        title: Colour
-        description: Describe the main colour to use i.e. blue, random
-        instill-format: string
-        instill-ui-order: 1
-    period:
-        title: Period
-        description: |
-            Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
-        instill-format: string
-    prompt:
-        title: Prompt
-        description: Input prompt here i.e. "A cute baby wombat"
-        instill-format: string
+  colour:
+    title: Colour
+    description: Describe the main colour to use i.e. blue, random
+    instill-format: string
+    instill-ui-order: 1
+  period:
+    title: Period
+    description: |
+      Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
+    instill-format: string
+  prompt:
+    title: Prompt
+    description: Input prompt here i.e. "A cute baby wombat"
+    instill-format: string
 output:
-    image:
-        title: Image
-        value: ${openai-0.output.results}
+  image:
+    title: Image
+    value: ${openai-0.output.results}
 ```

--- a/ai/mistralai/v0/README.mdx
+++ b/ai/mistralai/v0/README.mdx
@@ -138,72 +138,71 @@ Recipe for the [Short-film Script Writer](https://instill.tech/instill-ai/pipeli
 ```yaml
 version: v1beta
 component:
-    mistral-0:
-        type: mistral-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 1500
-            model-name: codestral-latest
-            prompt: |-
-                Generate a short-film movie script with the following placeholders:
-                [THEME]: ${variable.theme}
-                [GENRE]: ${variable.genre}
-                [NUM_ACTORS]: ${variable.num_actors}
-                [SETTING]: ${variable.setting}
-                [TIME_PERIOD]: The era or time frame of the story
-                [DURATION]: ${variable.duration}
-                [CONFLICT]: ${variable.conflict}
+  mistral-0:
+    type: mistral-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 1500
+      model-name: codestral-latest
+      prompt: |-
+        Generate a short-film movie script with the following placeholders:
+        [THEME]: ${variable.theme}
+        [GENRE]: ${variable.genre}
+        [NUM_ACTORS]: ${variable.num_actors}
+        [SETTING]: ${variable.setting}
+        [TIME_PERIOD]: The era or time frame of the story
+        [DURATION]: ${variable.duration}
+        [CONFLICT]: ${variable.conflict}
 
-                Please create a script that includes:
+        Please create a script that includes:
 
-                A brief synopsis (2-3 sentences)
-                Character descriptions for each main character
-                Scene-by-scene breakdown with dialogue and basic action descriptions
-                A conclusion that resolves the main conflict
+        A brief synopsis (2-3 sentences)
+        Character descriptions for each main character
+        Scene-by-scene breakdown with dialogue and basic action descriptions
+        A conclusion that resolves the main conflict
 
-                Ensure the script is coherent, engaging, and fits within the specified parameters. Be creative with the storytelling while maintaining the structure of a proper short film script.
-            safe: false
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        Ensure the script is coherent, engaging, and fits within the specified parameters. Be creative with the storytelling while maintaining the structure of a proper short film script.
+      safe: false
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    conflict:
-        title: Conflict
-        description: The main problem or challenge faced by the characters i.e. existential crisis
-        instill-format: string
-    duration:
-        title: Duration
-        description: Approximate length of the film in minutes i.e. 5
-        instill-format: string
-    genre:
-        title: Genre
-        description: The type of genre for this film i.e. romance, comedy, horror, action, etc.
-        instill-format: string
-    num_actors:
-        title: Num_actors
-        description: The number of actors that will be in this film i.e. 2
-        instill-format: string
-    setting:
-        title: Setting
-        description: |
-            The primary location where the story takes place i.e. Rome
-        instill-format: string
-    theme:
-        title: Theme
-        description: Insert the main theme or central idea of the film i.e. time travelling
-        instill-format: string
-    time-period:
-        title: Time Period
-        description: The era or time frame of the story i.e. stone age, 20th century, etc.
-        instill-format: string
+  conflict:
+    title: Conflict
+    description: The main problem or challenge faced by the characters i.e. existential crisis
+    instill-format: string
+  duration:
+    title: Duration
+    description: Approximate length of the film in minutes i.e. 5
+    instill-format: string
+  genre:
+    title: Genre
+    description: The type of genre for this film i.e. romance, comedy, horror, action, etc.
+    instill-format: string
+  num_actors:
+    title: Num_actors
+    description: The number of actors that will be in this film i.e. 2
+    instill-format: string
+  setting:
+    title: Setting
+    description: |
+      The primary location where the story takes place i.e. Rome
+    instill-format: string
+  theme:
+    title: Theme
+    description: Insert the main theme or central idea of the film i.e. time travelling
+    instill-format: string
+  time-period:
+    title: Time Period
+    description: The era or time frame of the story i.e. stone age, 20th century, etc.
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${mistral-0.output.text}
-
+  result:
+    title: Result
+    value: ${mistral-0.output.text}
 ```
 
 Recipe for the [PicassoAI: Cubist Creations at Your Command!](https://instill.tech/instill-ai/pipelines/picasso-ai/playground) pipeline.
@@ -211,70 +210,70 @@ Recipe for the [PicassoAI: Cubist Creations at Your Command!](https://instill.te
 ```yaml
 version: v1beta
 component:
-    mistral-0:
-        type: mistral-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 100
-            model-name: open-mixtral-8x22b
-            prompt: |-
-                Generate a Picasso-inspired image based on the following user input:
+  mistral-0:
+    type: mistral-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 100
+      model-name: open-mixtral-8x22b
+      prompt: |-
+        Generate a Picasso-inspired image based on the following user input:
 
-                ${variable.prompt}
+        ${variable.prompt}
 
-                Using the specified Picasso period: ${variable.period}
+        Using the specified Picasso period: ${variable.period}
 
 
-                Transform this input into a detailed text-to-image prompt by:
+        Transform this input into a detailed text-to-image prompt by:
 
-                1. Identifying the key elements or subjects in the user's description
+        1. Identifying the key elements or subjects in the user's description
 
-                2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
+        2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
 
-                3. Including cubist or abstract features characteristic of the ${variable.period}
+        3. Including cubist or abstract features characteristic of the ${variable.period}
 
-                4. Suggesting a composition or scene layout typical of Picasso's work from this era
+        4. Suggesting a composition or scene layout typical of Picasso's work from this era
 
-                Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
-            safe: false
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_TO_IMAGE
-        input:
-            model: dall-e-3
-            n: 1
-            prompt: |-
-                Using this primary color palette: ${variable.colour}
+        Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
+      safe: false
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_TO_IMAGE
+    input:
+      model: dall-e-3
+      n: 1
+      prompt: |-
+        Using this primary color palette: ${variable.colour}
 
-                ${mistral-0.output.text}
-            quality: standard
-            size: 1024x1024
-            style: vivid
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        ${mistral-0.output.text}
+      quality: standard
+      size: 1024x1024
+      style: vivid
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    colour:
-        title: Colour
-        description: Describe the main colour to use i.e. blue, random
-        instill-format: string
-        instill-ui-order: 1
-    period:
-        title: Period
-        description: |
-            Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
-        instill-format: string
-    prompt:
-        title: Prompt
-        description: Input prompt here i.e. "A cute baby wombat"
-        instill-format: string
+  colour:
+    title: Colour
+    description: Describe the main colour to use i.e. blue, random
+    instill-format: string
+    instill-ui-order: 1
+  period:
+    title: Period
+    description: |
+      Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
+    instill-format: string
+  prompt:
+    title: Prompt
+    description: Input prompt here i.e. "A cute baby wombat"
+    instill-format: string
 output:
-    image:
-        title: Image
-        value: ${openai-0.output.results}
+  image:
+    title: Image
+    value: ${openai-0.output.results}
 ```

--- a/ai/openai/v0/.compogen/bottom.mdx
+++ b/ai/openai/v0/.compogen/bottom.mdx
@@ -5,107 +5,106 @@ Recipe for the [PicassoAI: Cubist Creations at Your Command!](https://instill.te
 ```yaml
 version: v1beta
 component:
-    mistral-0:
-        type: mistral-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 100
-            model-name: open-mixtral-8x22b
-            prompt: |-
-                Generate a Picasso-inspired image based on the following user input:
+  mistral-0:
+    type: mistral-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 100
+      model-name: open-mixtral-8x22b
+      prompt: |-
+        Generate a Picasso-inspired image based on the following user input:
 
-                ${variable.prompt}
+        ${variable.prompt}
 
-                Using the specified Picasso period: ${variable.period}
+        Using the specified Picasso period: ${variable.period}
 
 
-                Transform this input into a detailed text-to-image prompt by:
+        Transform this input into a detailed text-to-image prompt by:
 
-                1. Identifying the key elements or subjects in the user's description
+        1. Identifying the key elements or subjects in the user's description
 
-                2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
+        2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
 
-                3. Including cubist or abstract features characteristic of the ${variable.period}
+        3. Including cubist or abstract features characteristic of the ${variable.period}
 
-                4. Suggesting a composition or scene layout typical of Picasso's work from this era
+        4. Suggesting a composition or scene layout typical of Picasso's work from this era
 
-                Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
-            safe: false
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_TO_IMAGE
-        input:
-            model: dall-e-3
-            n: 1
-            prompt: |-
-                Using this primary color palette: ${variable.colour}
+        Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
+      safe: false
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_TO_IMAGE
+    input:
+      model: dall-e-3
+      n: 1
+      prompt: |-
+        Using this primary color palette: ${variable.colour}
 
-                ${mistral-0.output.text}
-            quality: standard
-            size: 1024x1024
-            style: vivid
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        ${mistral-0.output.text}
+      quality: standard
+      size: 1024x1024
+      style: vivid
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    colour:
-        title: Colour
-        description: Describe the main colour to use i.e. blue, random
-        instill-format: string
-        instill-ui-order: 1
-    period:
-        title: Period
-        description: |
-            Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
-        instill-format: string
-    prompt:
-        title: Prompt
-        description: Input prompt here i.e. "A cute baby wombat"
-        instill-format: string
+  colour:
+    title: Colour
+    description: Describe the main colour to use i.e. blue, random
+    instill-format: string
+    instill-ui-order: 1
+  period:
+    title: Period
+    description: |
+      Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
+    instill-format: string
+  prompt:
+    title: Prompt
+    description: Input prompt here i.e. "A cute baby wombat"
+    instill-format: string
 output:
-    image:
-        title: Image
-        value: ${openai-0.output.results}
+  image:
+    title: Image
+    value: ${openai-0.output.results}
 ```
-
 
 Recipe for the [Explain this topic to me in another language](https://instill.tech/instill-ai/pipelines/gpt-4o-mini-demo/playground) pipeline.
 
 ```yaml
 version: v1beta
 component:
-    openai:
-        type: openai
-        task: TASK_TEXT_GENERATION
-        input:
-            model: gpt-4o-mini
-            n: 1
-            prompt: |-
-                Talk about this topic in ${variable.language}  in a concise and beginner-friendly way:
-                ${variable.prompt}
-            response-format:
-                type: text
-            system-message: You are a helpful assistant.
-            temperature: 1
-            top-p: 1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+  openai:
+    type: openai
+    task: TASK_TEXT_GENERATION
+    input:
+      model: gpt-4o-mini
+      n: 1
+      prompt: |-
+        Talk about this topic in ${variable.language}  in a concise and beginner-friendly way:
+        ${variable.prompt}
+      response-format:
+        type: text
+      system-message: You are a helpful assistant.
+      temperature: 1
+      top-p: 1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    language:
-        title: Language
-        description: Input a language i.e. Chinese, Japanese, French, etc.
-        instill-format: string
-    prompt:
-        title: Prompt
-        description: Write the topic you want to ask about here i.e. "Tell me about small LLMs"
-        instill-format: string
+  language:
+    title: Language
+    description: Input a language i.e. Chinese, Japanese, French, etc.
+    instill-format: string
+  prompt:
+    title: Prompt
+    description: Write the topic you want to ask about here i.e. "Tell me about small LLMs"
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${openai.output.texts}
+  result:
+    title: Result
+    value: ${openai.output.texts}
 ```

--- a/ai/openai/v0/README.mdx
+++ b/ai/openai/v0/README.mdx
@@ -234,107 +234,106 @@ Recipe for the [PicassoAI: Cubist Creations at Your Command!](https://instill.te
 ```yaml
 version: v1beta
 component:
-    mistral-0:
-        type: mistral-ai
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 100
-            model-name: open-mixtral-8x22b
-            prompt: |-
-                Generate a Picasso-inspired image based on the following user input:
+  mistral-0:
+    type: mistral-ai
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 100
+      model-name: open-mixtral-8x22b
+      prompt: |-
+        Generate a Picasso-inspired image based on the following user input:
 
-                ${variable.prompt}
+        ${variable.prompt}
 
-                Using the specified Picasso period: ${variable.period}
+        Using the specified Picasso period: ${variable.period}
 
 
-                Transform this input into a detailed text-to-image prompt by:
+        Transform this input into a detailed text-to-image prompt by:
 
-                1. Identifying the key elements or subjects in the user's description
+        1. Identifying the key elements or subjects in the user's description
 
-                2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
+        2. Adding artistic elements and techniques specific to the ${variable.period} period of Picasso's work
 
-                3. Including cubist or abstract features characteristic of the ${variable.period}
+        3. Including cubist or abstract features characteristic of the ${variable.period}
 
-                4. Suggesting a composition or scene layout typical of Picasso's work from this era
+        4. Suggesting a composition or scene layout typical of Picasso's work from this era
 
-                Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
-            safe: false
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-            top-p: 0.5
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_TO_IMAGE
-        input:
-            model: dall-e-3
-            n: 1
-            prompt: |-
-                Using this primary color palette: ${variable.colour}
+        Enhance the prompt with vivid, descriptive language and specific Picasso-style elements from the ${variable.period}. The final prompt should begin with "Create an image in the style of Picasso's ${variable.period} period:" followed by the enhanced description.
+      safe: false
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+      top-p: 0.5
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_TO_IMAGE
+    input:
+      model: dall-e-3
+      n: 1
+      prompt: |-
+        Using this primary color palette: ${variable.colour}
 
-                ${mistral-0.output.text}
-            quality: standard
-            size: 1024x1024
-            style: vivid
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        ${mistral-0.output.text}
+      quality: standard
+      size: 1024x1024
+      style: vivid
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    colour:
-        title: Colour
-        description: Describe the main colour to use i.e. blue, random
-        instill-format: string
-        instill-ui-order: 1
-    period:
-        title: Period
-        description: |
-            Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
-        instill-format: string
-    prompt:
-        title: Prompt
-        description: Input prompt here i.e. "A cute baby wombat"
-        instill-format: string
+  colour:
+    title: Colour
+    description: Describe the main colour to use i.e. blue, random
+    instill-format: string
+    instill-ui-order: 1
+  period:
+    title: Period
+    description: |
+      Input different Picasso periods i.e. Blue, Rose, African, Synthetic Cubism, etc.
+    instill-format: string
+  prompt:
+    title: Prompt
+    description: Input prompt here i.e. "A cute baby wombat"
+    instill-format: string
 output:
-    image:
-        title: Image
-        value: ${openai-0.output.results}
+  image:
+    title: Image
+    value: ${openai-0.output.results}
 ```
-
 
 Recipe for the [Explain this topic to me in another language](https://instill.tech/instill-ai/pipelines/gpt-4o-mini-demo/playground) pipeline.
 
 ```yaml
 version: v1beta
 component:
-    openai:
-        type: openai
-        task: TASK_TEXT_GENERATION
-        input:
-            model: gpt-4o-mini
-            n: 1
-            prompt: |-
-                Talk about this topic in ${variable.language}  in a concise and beginner-friendly way:
-                ${variable.prompt}
-            response-format:
-                type: text
-            system-message: You are a helpful assistant.
-            temperature: 1
-            top-p: 1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+  openai:
+    type: openai
+    task: TASK_TEXT_GENERATION
+    input:
+      model: gpt-4o-mini
+      n: 1
+      prompt: |-
+        Talk about this topic in ${variable.language}  in a concise and beginner-friendly way:
+        ${variable.prompt}
+      response-format:
+        type: text
+      system-message: You are a helpful assistant.
+      temperature: 1
+      top-p: 1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    language:
-        title: Language
-        description: Input a language i.e. Chinese, Japanese, French, etc.
-        instill-format: string
-    prompt:
-        title: Prompt
-        description: Write the topic you want to ask about here i.e. "Tell me about small LLMs"
-        instill-format: string
+  language:
+    title: Language
+    description: Input a language i.e. Chinese, Japanese, French, etc.
+    instill-format: string
+  prompt:
+    title: Prompt
+    description: Write the topic you want to ask about here i.e. "Tell me about small LLMs"
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${openai.output.texts}
+  result:
+    title: Result
+    value: ${openai.output.texts}
 ```

--- a/ai/universalai/v0/README.mdx
+++ b/ai/universalai/v0/README.mdx
@@ -51,18 +51,6 @@ Generate response base on conversation input
 <details>
 <summary> Input Objects in Chat</summary>
 
-<h4 id="chat-input-parameter">Input Parameter</h4>
-
-Input parameter
-
-| Field | Field ID | Type | Note |
-| :--- | :--- | :--- | :--- |
-| Max new tokens | `max-tokens` | integer | The maximum number of tokens for model to generate  |
-| Number of choices | `n` | integer | How many chat completion choices to generate for each input message.  |
-| Seed | `seed` | integer | The seed, default is 0  |
-| Stream | `stream` | boolean | If set, partial message deltas will be sent. Tokens will be sent as data-only server-sent events as they become available.  |
-| Temperature | `temperature` | number | The temperature for sampling  |
-| Top P | `top-p` | number | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.  |
 <h4 id="chat-chat-data">Chat Data</h4>
 
 Input data
@@ -80,6 +68,18 @@ List of chat messages
 | [Content](#chat-content) | `content` | array | The message content  |
 | Name | `name` | string | An optional name for the participant. Provides the model information to differentiate between participants of the same role.  |
 | Role | `role` | string | The message role, i.e. 'system', 'user' or 'assistant'  <br/><details><summary><strong>Enum values</strong></summary><ul><li>`system`</li><li>`user`</li><li>`assistant`</li></ul></details>  |
+<h4 id="chat-input-parameter">Input Parameter</h4>
+
+Input parameter
+
+| Field | Field ID | Type | Note |
+| :--- | :--- | :--- | :--- |
+| Max new tokens | `max-tokens` | integer | The maximum number of tokens for model to generate  |
+| Number of choices | `n` | integer | How many chat completion choices to generate for each input message.  |
+| Seed | `seed` | integer | The seed, default is 0  |
+| Stream | `stream` | boolean | If set, partial message deltas will be sent. Tokens will be sent as data-only server-sent events as they become available.  |
+| Temperature | `temperature` | number | The temperature for sampling  |
+| Top P | `top-p` | number | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.  |
 </details>
 
 

--- a/application/github/v0/.compogen/bottom.mdx
+++ b/application/github/v0/.compogen/bottom.mdx
@@ -5,44 +5,44 @@ Recipe for the [List GitHub Repo Issues](https://instill.tech/instill-ai/pipelin
 ```yaml
 version: v1beta
 component:
-    anthropic-0:
-        type: anthropic
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 1000
-            model-name: claude-3-5-sonnet-20240620
-            prompt: Summarise and pick the most important issues from this list ${github.output.issues}
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    github:
-        type: github
-        task: TASK_LIST_ISSUES
-        input:
-            direction: desc
-            no-pull-request: false
-            owner: ${variable.repository-owner}
-            page: 1
-            per-page: 30
-            repository: ${variable.repository-name}
-            since: "2021-01-01T00:00:00Z"
-            sort: created
-            state: open
-        setup:
-            token: ${secret.github-demo}
+  anthropic-0:
+    type: anthropic
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 1000
+      model-name: claude-3-5-sonnet-20240620
+      prompt: Summarise and pick the most important issues from this list ${github.output.issues}
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  github:
+    type: github
+    task: TASK_LIST_ISSUES
+    input:
+      direction: desc
+      no-pull-request: false
+      owner: ${variable.repository-owner}
+      page: 1
+      per-page: 30
+      repository: ${variable.repository-name}
+      since: "2021-01-01T00:00:00Z"
+      sort: created
+      state: open
+    setup:
+      token: ${secret.github-demo}
 variable:
-    repository-name:
-        title: Repository Name
-        description: Name of the repository i.e. instill-core
-        instill-format: string
-    repository-owner:
-        title: Repository Owner
-        description: Name of the repository owner i.e. instill-ai
-        instill-format: string
+  repository-name:
+    title: Repository Name
+    description: Name of the repository i.e. instill-core
+    instill-format: string
+  repository-owner:
+    title: Repository Owner
+    description: Name of the repository owner i.e. instill-ai
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${anthropic-0.output.text}
+  result:
+    title: Result
+    value: ${anthropic-0.output.text}
 ```

--- a/application/github/v0/README.mdx
+++ b/application/github/v0/README.mdx
@@ -473,44 +473,44 @@ Recipe for the [List GitHub Repo Issues](https://instill.tech/instill-ai/pipelin
 ```yaml
 version: v1beta
 component:
-    anthropic-0:
-        type: anthropic
-        task: TASK_TEXT_GENERATION_CHAT
-        input:
-            max-new-tokens: 1000
-            model-name: claude-3-5-sonnet-20240620
-            prompt: Summarise and pick the most important issues from this list ${github.output.issues}
-            system-message: You are a helpful assistant.
-            temperature: 0.7
-            top-k: 10
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    github:
-        type: github
-        task: TASK_LIST_ISSUES
-        input:
-            direction: desc
-            no-pull-request: false
-            owner: ${variable.repository-owner}
-            page: 1
-            per-page: 30
-            repository: ${variable.repository-name}
-            since: "2021-01-01T00:00:00Z"
-            sort: created
-            state: open
-        setup:
-            token: ${secret.github-demo}
+  anthropic-0:
+    type: anthropic
+    task: TASK_TEXT_GENERATION_CHAT
+    input:
+      max-new-tokens: 1000
+      model-name: claude-3-5-sonnet-20240620
+      prompt: Summarise and pick the most important issues from this list ${github.output.issues}
+      system-message: You are a helpful assistant.
+      temperature: 0.7
+      top-k: 10
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  github:
+    type: github
+    task: TASK_LIST_ISSUES
+    input:
+      direction: desc
+      no-pull-request: false
+      owner: ${variable.repository-owner}
+      page: 1
+      per-page: 30
+      repository: ${variable.repository-name}
+      since: "2021-01-01T00:00:00Z"
+      sort: created
+      state: open
+    setup:
+      token: ${secret.github-demo}
 variable:
-    repository-name:
-        title: Repository Name
-        description: Name of the repository i.e. instill-core
-        instill-format: string
-    repository-owner:
-        title: Repository Owner
-        description: Name of the repository owner i.e. instill-ai
-        instill-format: string
+  repository-name:
+    title: Repository Name
+    description: Name of the repository i.e. instill-core
+    instill-format: string
+  repository-owner:
+    title: Repository Owner
+    description: Name of the repository owner i.e. instill-ai
+    instill-format: string
 output:
-    result:
-        title: Result
-        value: ${anthropic-0.output.text}
+  result:
+    title: Result
+    value: ${anthropic-0.output.text}
 ```

--- a/application/jira/v0/.compogen/bottom.mdx
+++ b/application/jira/v0/.compogen/bottom.mdx
@@ -5,63 +5,63 @@ Recipe for the [Your Project Management Assistant ](https://instill.tech/instill
 ```yaml
 version: v1beta
 component:
-    jira-0:
-        type: jira
-        task: TASK_LIST_ISSUES
-        input:
-            board-name: ${variable.board-name}
-            max-results: 50
-            range:
-                range: All
-            start-at: 0
-        setup:
-            base-url: ${variable.base-url}
-            email: ${variable.jira-email}
-            token: ${secret.jira}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_GENERATION
-        input:
-            model: gpt-4o-mini
-            n: 1
-            prompt: |-
-                From this list of issues:
-                ${jira-0.output.issues}
+  jira-0:
+    type: jira
+    task: TASK_LIST_ISSUES
+    input:
+      board-name: ${variable.board-name}
+      max-results: 50
+      range:
+        range: All
+      start-at: 0
+    setup:
+      base-url: ${variable.base-url}
+      email: ${variable.jira-email}
+      token: ${secret.jira}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_GENERATION
+    input:
+      model: gpt-4o-mini
+      n: 1
+      prompt: |-
+        From this list of issues:
+        ${jira-0.output.issues}
 
 
-                Summarise the next action items and reference the relevant issues.
+        Summarise the next action items and reference the relevant issues.
 
-                Category:
-                [list of relevant issues]
-            response-format:
-                type: text
-            system-message: |-
-                You are an expert project manager. Classify the issues into one of the following categories: ["feature", "bug", "refactor", "cancelled"]
+        Category:
+        [list of relevant issues]
+      response-format:
+        type: text
+      system-message: |-
+        You are an expert project manager. Classify the issues into one of the following categories: ["feature", "bug", "refactor", "cancelled"]
 
-                If anything is a breaking change, make it a top priority.
-            temperature: 1
-            top-p: 1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        If anything is a breaking change, make it a top priority.
+      temperature: 1
+      top-p: 1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    base-url:
-        title: Jira Base URL
-        description: |+
-            Your Jira base URL i.e. https://<_YOUR_COMPANY_>.atlassian.net
+  base-url:
+    title: Jira Base URL
+    description: |+
+      Your Jira base URL i.e. https://<_YOUR_COMPANY_>.atlassian.net
 
-        instill-format: string
-    board-name:
-        title: Jira Board Name
-        description: |+
-            The name of your Jira board i.e. "KANBAN board".
+    instill-format: string
+  board-name:
+    title: Jira Board Name
+    description: |+
+      The name of your Jira board i.e. "KANBAN board".
 
-        instill-format: string
-    jira-email:
-        title: Jira Email
-        description: The email you are using for Jira i.e. hello@world.com
-        instill-format: string
+    instill-format: string
+  jira-email:
+    title: Jira Email
+    description: The email you are using for Jira i.e. hello@world.com
+    instill-format: string
 output:
-    output:
-        title: Output
-        value: ${openai-0.output.texts}
+  output:
+    title: Output
+    value: ${openai-0.output.texts}
 ```

--- a/application/jira/v0/README.mdx
+++ b/application/jira/v0/README.mdx
@@ -470,63 +470,63 @@ Recipe for the [Your Project Management Assistant ](https://instill.tech/instill
 ```yaml
 version: v1beta
 component:
-    jira-0:
-        type: jira
-        task: TASK_LIST_ISSUES
-        input:
-            board-name: ${variable.board-name}
-            max-results: 50
-            range:
-                range: All
-            start-at: 0
-        setup:
-            base-url: ${variable.base-url}
-            email: ${variable.jira-email}
-            token: ${secret.jira}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_GENERATION
-        input:
-            model: gpt-4o-mini
-            n: 1
-            prompt: |-
-                From this list of issues:
-                ${jira-0.output.issues}
+  jira-0:
+    type: jira
+    task: TASK_LIST_ISSUES
+    input:
+      board-name: ${variable.board-name}
+      max-results: 50
+      range:
+        range: All
+      start-at: 0
+    setup:
+      base-url: ${variable.base-url}
+      email: ${variable.jira-email}
+      token: ${secret.jira}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_GENERATION
+    input:
+      model: gpt-4o-mini
+      n: 1
+      prompt: |-
+        From this list of issues:
+        ${jira-0.output.issues}
 
 
-                Summarise the next action items and reference the relevant issues.
+        Summarise the next action items and reference the relevant issues.
 
-                Category:
-                [list of relevant issues]
-            response-format:
-                type: text
-            system-message: |-
-                You are an expert project manager. Classify the issues into one of the following categories: ["feature", "bug", "refactor", "cancelled"]
+        Category:
+        [list of relevant issues]
+      response-format:
+        type: text
+      system-message: |-
+        You are an expert project manager. Classify the issues into one of the following categories: ["feature", "bug", "refactor", "cancelled"]
 
-                If anything is a breaking change, make it a top priority.
-            temperature: 1
-            top-p: 1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+        If anything is a breaking change, make it a top priority.
+      temperature: 1
+      top-p: 1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    base-url:
-        title: Jira Base URL
-        description: |+
-            Your Jira base URL i.e. https://<_YOUR_COMPANY_>.atlassian.net
+  base-url:
+    title: Jira Base URL
+    description: |+
+      Your Jira base URL i.e. https://<_YOUR_COMPANY_>.atlassian.net
 
-        instill-format: string
-    board-name:
-        title: Jira Board Name
-        description: |+
-            The name of your Jira board i.e. "KANBAN board".
+    instill-format: string
+  board-name:
+    title: Jira Board Name
+    description: |+
+      The name of your Jira board i.e. "KANBAN board".
 
-        instill-format: string
-    jira-email:
-        title: Jira Email
-        description: The email you are using for Jira i.e. hello@world.com
-        instill-format: string
+    instill-format: string
+  jira-email:
+    title: Jira Email
+    description: The email you are using for Jira i.e. hello@world.com
+    instill-format: string
 output:
-    output:
-        title: Output
-        value: ${openai-0.output.texts}
+  output:
+    title: Output
+    value: ${openai-0.output.texts}
 ```

--- a/data/instillartifact/v0/.compogen/bottom.mdx
+++ b/data/instillartifact/v0/.compogen/bottom.mdx
@@ -5,29 +5,29 @@ Recipe for the [Ask your Catalog](https://instill.tech/instill-ai/pipelines/ask-
 ```yaml
 version: v1beta
 component:
-    artifact-0:
-        type: instill-artifact
-        task: TASK_ASK
-        input:
-            catalog-id: ${variable.catalog_name}
-            namespace: ${variable.namespace}
-            question: ${variable.question}
-            top-k: 5
+  artifact-0:
+    type: instill-artifact
+    task: TASK_ASK
+    input:
+      catalog-id: ${variable.catalog_name}
+      namespace: ${variable.namespace}
+      question: ${variable.question}
+      top-k: 5
 variable:
-    catalog_name:
-        title: catalog-name
-        description: The name of your catalog i.e. "instill-ai"
-        instill-format: string
-    namespace:
-        title: namespace
-        description: The namespace of your catalog i.e. "instill-ai"
-        instill-format: string
-    question:
-        title: question
-        description: The question to ask your catalog i.e. "What is Instill AI doing?", "What is Artifact?"
-        instill-format: string
+  catalog_name:
+    title: catalog-name
+    description: The name of your catalog i.e. "instill-ai"
+    instill-format: string
+  namespace:
+    title: namespace
+    description: The namespace of your catalog i.e. "instill-ai"
+    instill-format: string
+  question:
+    title: question
+    description: The question to ask your catalog i.e. "What is Instill AI doing?", "What is Artifact?"
+    instill-format: string
 output:
-    answer:
-        title: answer
-        value: ${artifact-0.output.answer}
+  answer:
+    title: answer
+    value: ${artifact-0.output.answer}
 ```

--- a/data/instillartifact/v0/README.mdx
+++ b/data/instillartifact/v0/README.mdx
@@ -338,29 +338,29 @@ Recipe for the [Ask your Catalog](https://instill.tech/instill-ai/pipelines/ask-
 ```yaml
 version: v1beta
 component:
-    artifact-0:
-        type: instill-artifact
-        task: TASK_ASK
-        input:
-            catalog-id: ${variable.catalog_name}
-            namespace: ${variable.namespace}
-            question: ${variable.question}
-            top-k: 5
+  artifact-0:
+    type: instill-artifact
+    task: TASK_ASK
+    input:
+      catalog-id: ${variable.catalog_name}
+      namespace: ${variable.namespace}
+      question: ${variable.question}
+      top-k: 5
 variable:
-    catalog_name:
-        title: catalog-name
-        description: The name of your catalog i.e. "instill-ai"
-        instill-format: string
-    namespace:
-        title: namespace
-        description: The namespace of your catalog i.e. "instill-ai"
-        instill-format: string
-    question:
-        title: question
-        description: The question to ask your catalog i.e. "What is Instill AI doing?", "What is Artifact?"
-        instill-format: string
+  catalog_name:
+    title: catalog-name
+    description: The name of your catalog i.e. "instill-ai"
+    instill-format: string
+  namespace:
+    title: namespace
+    description: The namespace of your catalog i.e. "instill-ai"
+    instill-format: string
+  question:
+    title: question
+    description: The question to ask your catalog i.e. "What is Instill AI doing?", "What is Artifact?"
+    instill-format: string
 output:
-    answer:
-        title: answer
-        value: ${artifact-0.output.answer}
+  answer:
+    title: answer
+    value: ${artifact-0.output.answer}
 ```

--- a/operator/audio/v0/.compogen/bottom.mdx
+++ b/operator/audio/v0/.compogen/bottom.mdx
@@ -5,37 +5,36 @@ Recipe for the [Audio Transcription Generator](https://instill.tech/instill-ai/p
 ```yaml
 version: v1beta
 component:
-    audio-spliter:
-        type: audio
-        task: TASK_SLICE_AUDIO
-        input:
-            audio: ${variable.audio}
-            end-time: ${variable.end_time}
-            start-time: ${variable.start_time}
-    get-transcription:
-        type: openai
-        task: TASK_SPEECH_RECOGNITION
-        input:
-            audio: ${audio-spliter.output.audio}
-            model: whisper-1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+  audio-spliter:
+    type: audio
+    task: TASK_SLICE_AUDIO
+    input:
+      audio: ${variable.audio}
+      end-time: ${variable.end_time}
+      start-time: ${variable.start_time}
+  get-transcription:
+    type: openai
+    task: TASK_SPEECH_RECOGNITION
+    input:
+      audio: ${audio-spliter.output.audio}
+      model: whisper-1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    audio:
-        title: audio
-        description: the audio you want to get the transcription from
-        instill-format: audio/*
-    end_time:
-        title: end-time
-        description: the end time you want to extract in seconds i.e. 2 mins is 120 seconds
-        instill-format: number
-    start_time:
-        title: start-time
-        description: the start time you want to extract in seconds i.e. 2 mins is 120 seconds
-        instill-format: number
+  audio:
+    title: audio
+    description: the audio you want to get the transcription from
+    instill-format: audio/*
+  end_time:
+    title: end-time
+    description: the end time you want to extract in seconds i.e. 2 mins is 120 seconds
+    instill-format: number
+  start_time:
+    title: start-time
+    description: the start time you want to extract in seconds i.e. 2 mins is 120 seconds
+    instill-format: number
 output:
-    result:
-        title: result
-        value: ${get-transcription.output.text}
-
+  result:
+    title: result
+    value: ${get-transcription.output.text}
 ```

--- a/operator/audio/v0/README.mdx
+++ b/operator/audio/v0/README.mdx
@@ -65,37 +65,36 @@ Recipe for the [Audio Transcription Generator](https://instill.tech/instill-ai/p
 ```yaml
 version: v1beta
 component:
-    audio-spliter:
-        type: audio
-        task: TASK_SLICE_AUDIO
-        input:
-            audio: ${variable.audio}
-            end-time: ${variable.end_time}
-            start-time: ${variable.start_time}
-    get-transcription:
-        type: openai
-        task: TASK_SPEECH_RECOGNITION
-        input:
-            audio: ${audio-spliter.output.audio}
-            model: whisper-1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
+  audio-spliter:
+    type: audio
+    task: TASK_SLICE_AUDIO
+    input:
+      audio: ${variable.audio}
+      end-time: ${variable.end_time}
+      start-time: ${variable.start_time}
+  get-transcription:
+    type: openai
+    task: TASK_SPEECH_RECOGNITION
+    input:
+      audio: ${audio-spliter.output.audio}
+      model: whisper-1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
 variable:
-    audio:
-        title: audio
-        description: the audio you want to get the transcription from
-        instill-format: audio/*
-    end_time:
-        title: end-time
-        description: the end time you want to extract in seconds i.e. 2 mins is 120 seconds
-        instill-format: number
-    start_time:
-        title: start-time
-        description: the start time you want to extract in seconds i.e. 2 mins is 120 seconds
-        instill-format: number
+  audio:
+    title: audio
+    description: the audio you want to get the transcription from
+    instill-format: audio/*
+  end_time:
+    title: end-time
+    description: the end time you want to extract in seconds i.e. 2 mins is 120 seconds
+    instill-format: number
+  start_time:
+    title: start-time
+    description: the start time you want to extract in seconds i.e. 2 mins is 120 seconds
+    instill-format: number
 output:
-    result:
-        title: result
-        value: ${get-transcription.output.text}
-
+  result:
+    title: result
+    value: ${get-transcription.output.text}
 ```

--- a/operator/json/v0/.compogen/bottom.mdx
+++ b/operator/json/v0/.compogen/bottom.mdx
@@ -5,91 +5,91 @@ Recipe for the [Resume Screening](https://instill.tech/instill-ai/pipelines/stru
 ```yaml
 version: v1beta
 component:
-    json-0:
-        type: json
-        task: TASK_UNMARSHAL
-        input:
-            string: ${openai-0.output.texts[0]}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_GENERATION
-        input:
-            model: gpt-4o-2024-08-06
-            n: 1
-            prompt: |
-                Given an ${variable.resume} and a ${pdf-to-text.output.body}, create an automated system to screen and convert this information into a structured candidate profile. The system should extract key information such as:
+  json-0:
+    type: json
+    task: TASK_UNMARSHAL
+    input:
+      string: ${openai-0.output.texts[0]}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_GENERATION
+    input:
+      model: gpt-4o-2024-08-06
+      n: 1
+      prompt: |
+        Given an ${variable.resume} and a ${pdf-to-text.output.body}, create an automated system to screen and convert this information into a structured candidate profile. The system should extract key information such as:
 
-                Skills: Identify and list relevant skills mentioned in the resume.
-                Experience: Extract work history including job titles, companies, durations, and responsibilities from the resume.
-                Education: Capture educational background including degrees, institutions, and graduation dates from the resume.
-                Certifications: Identify any professional certifications or additional qualifications in the resume.
-                Fit Score: Calculate a fit score based on the alignment of the candidate's profile with the job description, taking into account required skills, experience level, and education.
-            response-format:
-                json-schema: |-
-                    {
-                        "name": "resume_response",
-                        "strict": true,
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "education": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "reasoning": {
-                                    "type": "string"
-                                },
-                                "experience": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "skills": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "required": [
-                                "name",
-                                "education",
-                                "score",
-                                "reasoning",
-                                "experience",
-                                "skills"
-                            ],
-                            "additionalProperties": false
-                        }
-                    }
-                type: json_schema
-            system-message: You are a helpful assistant.
-            temperature: 1
-            top-p: 1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    pdf-to-text:
-        type: document
-        task: TASK_CONVERT_TO_TEXT
-        input:
-            document: ${variable.resume}
+        Skills: Identify and list relevant skills mentioned in the resume.
+        Experience: Extract work history including job titles, companies, durations, and responsibilities from the resume.
+        Education: Capture educational background including degrees, institutions, and graduation dates from the resume.
+        Certifications: Identify any professional certifications or additional qualifications in the resume.
+        Fit Score: Calculate a fit score based on the alignment of the candidate's profile with the job description, taking into account required skills, experience level, and education.
+      response-format:
+        json-schema: |-
+          {
+              "name": "resume_response",
+              "strict": true,
+              "schema": {
+                  "type": "object",
+                  "properties": {
+                      "name": {
+                          "type": "string"
+                      },
+                      "education": {
+                          "type": "string"
+                      },
+                      "score": {
+                          "type": "number"
+                      },
+                      "reasoning": {
+                          "type": "string"
+                      },
+                      "experience": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      },
+                      "skills": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      }
+                  },
+                  "required": [
+                      "name",
+                      "education",
+                      "score",
+                      "reasoning",
+                      "experience",
+                      "skills"
+                  ],
+                  "additionalProperties": false
+              }
+          }
+        type: json_schema
+      system-message: You are a helpful assistant.
+      temperature: 1
+      top-p: 1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  pdf-to-text:
+    type: document
+    task: TASK_CONVERT_TO_TEXT
+    input:
+      document: ${variable.resume}
 variable:
-    job-description:
-        title: job description
-        description: The text of the job description.
-        instill-format: string
-    resume:
-        title: resume
-        description: The PDF file of the candidates resume
-        instill-format: '*/*'
+  job-description:
+    title: job description
+    description: The text of the job description.
+    instill-format: string
+  resume:
+    title: resume
+    description: The PDF file of the candidates resume
+    instill-format: "*/*"
 output:
-    output:
-        title: output
-        value: ${json-0.output.json}
+  output:
+    title: output
+    value: ${json-0.output.json}
 ```

--- a/operator/json/v0/README.mdx
+++ b/operator/json/v0/README.mdx
@@ -96,91 +96,91 @@ Recipe for the [Resume Screening](https://instill.tech/instill-ai/pipelines/stru
 ```yaml
 version: v1beta
 component:
-    json-0:
-        type: json
-        task: TASK_UNMARSHAL
-        input:
-            string: ${openai-0.output.texts[0]}
-    openai-0:
-        type: openai
-        task: TASK_TEXT_GENERATION
-        input:
-            model: gpt-4o-2024-08-06
-            n: 1
-            prompt: |
-                Given an ${variable.resume} and a ${pdf-to-text.output.body}, create an automated system to screen and convert this information into a structured candidate profile. The system should extract key information such as:
+  json-0:
+    type: json
+    task: TASK_UNMARSHAL
+    input:
+      string: ${openai-0.output.texts[0]}
+  openai-0:
+    type: openai
+    task: TASK_TEXT_GENERATION
+    input:
+      model: gpt-4o-2024-08-06
+      n: 1
+      prompt: |
+        Given an ${variable.resume} and a ${pdf-to-text.output.body}, create an automated system to screen and convert this information into a structured candidate profile. The system should extract key information such as:
 
-                Skills: Identify and list relevant skills mentioned in the resume.
-                Experience: Extract work history including job titles, companies, durations, and responsibilities from the resume.
-                Education: Capture educational background including degrees, institutions, and graduation dates from the resume.
-                Certifications: Identify any professional certifications or additional qualifications in the resume.
-                Fit Score: Calculate a fit score based on the alignment of the candidate's profile with the job description, taking into account required skills, experience level, and education.
-            response-format:
-                json-schema: |-
-                    {
-                        "name": "resume_response",
-                        "strict": true,
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "education": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "reasoning": {
-                                    "type": "string"
-                                },
-                                "experience": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "skills": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "required": [
-                                "name",
-                                "education",
-                                "score",
-                                "reasoning",
-                                "experience",
-                                "skills"
-                            ],
-                            "additionalProperties": false
-                        }
-                    }
-                type: json_schema
-            system-message: You are a helpful assistant.
-            temperature: 1
-            top-p: 1
-        setup:
-            api-key: ${secret.INSTILL_SECRET}
-    pdf-to-text:
-        type: document
-        task: TASK_CONVERT_TO_TEXT
-        input:
-            document: ${variable.resume}
+        Skills: Identify and list relevant skills mentioned in the resume.
+        Experience: Extract work history including job titles, companies, durations, and responsibilities from the resume.
+        Education: Capture educational background including degrees, institutions, and graduation dates from the resume.
+        Certifications: Identify any professional certifications or additional qualifications in the resume.
+        Fit Score: Calculate a fit score based on the alignment of the candidate's profile with the job description, taking into account required skills, experience level, and education.
+      response-format:
+        json-schema: |-
+          {
+              "name": "resume_response",
+              "strict": true,
+              "schema": {
+                  "type": "object",
+                  "properties": {
+                      "name": {
+                          "type": "string"
+                      },
+                      "education": {
+                          "type": "string"
+                      },
+                      "score": {
+                          "type": "number"
+                      },
+                      "reasoning": {
+                          "type": "string"
+                      },
+                      "experience": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      },
+                      "skills": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      }
+                  },
+                  "required": [
+                      "name",
+                      "education",
+                      "score",
+                      "reasoning",
+                      "experience",
+                      "skills"
+                  ],
+                  "additionalProperties": false
+              }
+          }
+        type: json_schema
+      system-message: You are a helpful assistant.
+      temperature: 1
+      top-p: 1
+    setup:
+      api-key: ${secret.INSTILL_SECRET}
+  pdf-to-text:
+    type: document
+    task: TASK_CONVERT_TO_TEXT
+    input:
+      document: ${variable.resume}
 variable:
-    job-description:
-        title: job description
-        description: The text of the job description.
-        instill-format: string
-    resume:
-        title: resume
-        description: The PDF file of the candidates resume
-        instill-format: '*/*'
+  job-description:
+    title: job description
+    description: The text of the job description.
+    instill-format: string
+  resume:
+    title: resume
+    description: The PDF file of the candidates resume
+    instill-format: "*/*"
 output:
-    output:
-        title: output
-        value: ${json-0.output.json}
+  output:
+    title: output
+    value: ${json-0.output.json}
 ```

--- a/operator/web/v0/.compogen/bottom.mdx
+++ b/operator/web/v0/.compogen/bottom.mdx
@@ -5,20 +5,20 @@ Recipe for the [Web scraper](https://instill.tech/instill-ai/pipelines/web-scrap
 ```yaml
 version: v1beta
 component:
-    scraper:
-        type: web
-        task: TASK_SCRAPE_WEBPAGE
-        input:
-            include-html: false
-            only-main-content: true
-            url: ${variable.url}
+  scraper:
+    type: web
+    task: TASK_SCRAPE_WEBPAGE
+    input:
+      include-html: false
+      only-main-content: true
+      url: ${variable.url}
 variable:
-    url:
-        title: url
-        description: The url of the web you want to scrape
-        instill-format: string
+  url:
+    title: url
+    description: The url of the web you want to scrape
+    instill-format: string
 output:
-    markdown:
-        title: markdown
-        value: ${scraper.output.markdown}
+  markdown:
+    title: markdown
+    value: ${scraper.output.markdown}
 ```

--- a/operator/web/v0/README.mdx
+++ b/operator/web/v0/README.mdx
@@ -122,20 +122,20 @@ Recipe for the [Web scraper](https://instill.tech/instill-ai/pipelines/web-scrap
 ```yaml
 version: v1beta
 component:
-    scraper:
-        type: web
-        task: TASK_SCRAPE_WEBPAGE
-        input:
-            include-html: false
-            only-main-content: true
-            url: ${variable.url}
+  scraper:
+    type: web
+    task: TASK_SCRAPE_WEBPAGE
+    input:
+      include-html: false
+      only-main-content: true
+      url: ${variable.url}
 variable:
-    url:
-        title: url
-        description: The url of the web you want to scrape
-        instill-format: string
+  url:
+    title: url
+    description: The url of the web you want to scrape
+    instill-format: string
 output:
-    markdown:
-        title: markdown
-        value: ${scraper.output.markdown}
+  markdown:
+    title: markdown
+    value: ${scraper.output.markdown}
 ```


### PR DESCRIPTION
Because

- we'd like to make YAML format consistent in the codebase

This commit

- use pre-commit hook [yamlfmt](https://github.com/jumanjihouse/pre-commit-hook-yamlfmt) and set space indent 2 by default for all YAML codeblocks
