### PR TITLE
chore(collection): rename TASK_APPEND_ARRAY to TASK_APPEND

### DIFF
--- a/generic/collection/v0/README.mdx
+++ b/generic/collection/v0/README.mdx
@@ -8,7 +8,7 @@ description: "Learn about how to set up a VDP Collection component https://githu
 The Collection component is a generic component that allows users to manipulate collection-type data.
 It can carry out the following tasks:
 - [Assign](#assign)
-- [Append Array](#append-array)
+- [Append](#append)
 - [Union](#union)
 - [Intersection](#intersection)
 - [Difference](#difference)
@@ -42,13 +42,13 @@ Assign the data.
 | :--- | :--- | :--- | :--- |
 | Data | `data` | any | The data you assign. |
 
-### Append Array
+### Append
 
 Add data to the end of an array.
 
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Task ID (required) | `task` | string | `TASK_APPEND_ARRAY` |
+| Task ID (required) | `task` | string | `TASK_APPEND` |
 | Array (required) | `array` | array | Specify the array you want to append to. |
 | Data (required) | `element` | any | Specify the data you want to append. |
 

--- a/generic/collection/v0/config/definition.json
+++ b/generic/collection/v0/config/definition.json
@@ -1,7 +1,7 @@
 {
   "availableTasks": [
     "TASK_ASSIGN",
-    "TASK_APPEND_ARRAY",
+    "TASK_APPEND",
     "TASK_UNION",
     "TASK_INTERSECTION",
     "TASK_DIFFERENCE"

--- a/generic/collection/v0/config/tasks.json
+++ b/generic/collection/v0/config/tasks.json
@@ -53,7 +53,7 @@
       "type": "object"
     }
   },
-  "TASK_APPEND_ARRAY": {
+  "TASK_APPEND": {
     "instillShortDescription": "Add data to the end of an array.",
     "input": {
       "description": "Input",

--- a/generic/collection/v0/main.go
+++ b/generic/collection/v0/main.go
@@ -22,7 +22,7 @@ const (
 	taskUnion        = "TASK_UNION"
 	taskIntersection = "TASK_INTERSECTION"
 	taskDifference   = "TASK_DIFFERENCE"
-	taskAppendArray  = "TASK_APPEND_ARRAY"
+	taskAppend       = "TASK_APPEND"
 )
 
 var (
@@ -71,8 +71,8 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 		e.execute = e.intersection
 	case taskDifference:
 		e.execute = e.difference
-	case taskAppendArray:
-		e.execute = e.appendArray
+	case taskAppend:
+		e.execute = e.append
 	default:
 		return nil, errmsg.AddMessage(
 			fmt.Errorf("not supported task: %s", x.Task),
@@ -220,10 +220,10 @@ func (e *execution) assign(in *structpb.Struct) (*structpb.Struct, error) {
 	return out, nil
 }
 
-func (e *execution) appendArray(in *structpb.Struct) (*structpb.Struct, error) {
+func (e *execution) append(in *structpb.Struct) (*structpb.Struct, error) {
 	arr := in.Fields["array"]
-	data := in.Fields["element"]
-	arr.GetListValue().Values = append(arr.GetListValue().Values, data)
+	element := in.Fields["element"]
+	arr.GetListValue().Values = append(arr.GetListValue().Values, element)
 
 	out := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
 	out.Fields["array"] = arr


### PR DESCRIPTION
Because

- The Append operation always applies to an array, so there’s no need to name it as `TASK_APPEND_ARRAY`.

This commit

- Renames `TASK_APPEND_ARRAY` to `TASK_APPEND`.