### PR TITLE
Pinglin/fix title format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
-build-doc:
-	@cd ./tools/compogen && go install .
-
 gen-doc:
 	@rm -f $$(find . -name README.mdx | paste -d ' ' -s -)
+	@cd ./tools/compogen && go install .
 	@go generate -run compogen ./...
 
 gen-mock:

--- a/ai/huggingface/v0/README.mdx
+++ b/ai/huggingface/v0/README.mdx
@@ -21,7 +21,7 @@ It can carry out the following tasks:
 - [Image Classification](#image-classification)
 - [Image Segmentation](#image-segmentation)
 - [Object Detection](#object-detection)
-- [Image To Text](#image-to-text)
+- [Image to Text](#image-to-text)
 - [Speech Recognition](#speech-recognition)
 - [Audio Classification](#audio-classification)
 
@@ -639,7 +639,7 @@ Object Detection models allow users to identify objects of certain defined class
 | Y min | `ymin` | number | Y min |
 </details>
 
-### Image To Text
+### Image to Text
 
 Image to text models output a text from a given image. Image captioning or optical character recognition can be considered as the most common applications of image to text.
 

--- a/ai/instill/v0/README.mdx
+++ b/ai/instill/v0/README.mdx
@@ -11,11 +11,11 @@ It can carry out the following tasks:
 - [Instance Segmentation](#instance-segmentation)
 - [Keypoint](#keypoint)
 - [Detection](#detection)
-- [Ocr](#ocr)
+- [OCR](#ocr)
 - [Semantic Segmentation](#semantic-segmentation)
 - [Text Generation](#text-generation)
 - [Text Generation Chat](#text-generation-chat)
-- [Text To Image](#text-to-image)
+- [Text to Image](#text-to-image)
 - [Visual Question Answering](#visual-question-answering)
 - [Chat](#chat)
 
@@ -176,7 +176,7 @@ Detect and localize multiple objects in images.
 | Width | `width` | number | Bounding box width value |
 </details>
 
-### Ocr
+### OCR
 
 Detect and recognize text in images.
 
@@ -195,7 +195,7 @@ Detect and recognize text in images.
 | [Objects](#ocr-objects) | `objects` | array[object] | A list of detected bounding boxes. |
 
 <details>
-<summary> Output Objects in Ocr</summary>
+<summary> Output Objects in OCR</summary>
 
 <h4 id="ocr-objects">Objects</h4>
 
@@ -317,7 +317,7 @@ The image URL
 | :--- | :--- | :--- | :--- |
 | Text | `text` | string | Text |
 
-### Text To Image
+### Text to Image
 
 Generate images from input text prompts.
 

--- a/ai/openai/v0/README.mdx
+++ b/ai/openai/v0/README.mdx
@@ -10,8 +10,8 @@ It can carry out the following tasks:
 - [Text Generation](#text-generation)
 - [Text Embeddings](#text-embeddings)
 - [Speech Recognition](#speech-recognition)
-- [Text To Speech](#text-to-speech)
-- [Text To Image](#text-to-image)
+- [Text to Speech](#text-to-speech)
+- [Text to Image](#text-to-image)
 
 ## Release Stage
 
@@ -174,7 +174,7 @@ Turn audio into text.
 | :--- | :--- | :--- | :--- |
 | Text | `text` | string | Generated text |
 
-### Text To Speech
+### Text to Speech
 
 Turn text into lifelike spoken audio
 
@@ -195,7 +195,7 @@ Turn text into lifelike spoken audio
 | :--- | :--- | :--- | :--- |
 | Audio (optional) | `audio` | string | AI generated audio |
 
-### Text To Image
+### Text to Image
 
 Generate or manipulate images with DALL·E.
 
@@ -218,7 +218,7 @@ Generate or manipulate images with DALL·E.
 | [Images](#text-to-image-images) | `results` | array[object] | Generated results |
 
 <details>
-<summary> Output Objects in Text To Image</summary>
+<summary> Output Objects in Text to Image</summary>
 
 <h4 id="text-to-image-images">Images</h4>
 

--- a/ai/stabilityai/v0/README.mdx
+++ b/ai/stabilityai/v0/README.mdx
@@ -7,8 +7,8 @@ description: "Learn about how to set up a VDP Stability AI component https://git
 
 The Stability AI component is an AI component that allows users to connect the AI models served on the Stability AI Platform.
 It can carry out the following tasks:
-- [Text To Image](#text-to-image)
-- [Image To Image](#image-to-image)
+- [Text to Image](#text-to-image)
+- [Image to Image](#image-to-image)
 
 ## Release Stage
 
@@ -37,7 +37,7 @@ ${connection.<my-connection-id>}`.
 
 ## Supported Tasks
 
-### Text To Image
+### Text to Image
 
 Generate a new image from a text prompt.
 
@@ -66,7 +66,7 @@ Generate a new image from a text prompt.
 | Images | `images` | array[string] | Generated images |
 | Seeds | `seeds` | array[number] | Seeds of generated images |
 
-### Image To Image
+### Image to Image
 
 Modify an image based on a text prompt.
 

--- a/application/freshdesk/v0/README.mdx
+++ b/application/freshdesk/v0/README.mdx
@@ -9,7 +9,7 @@ The Freshdesk component is an application component that allows users to use Fre
 It can carry out the following tasks:
 - [Get Ticket](#get-ticket)
 - [Create Ticket](#create-ticket)
-- [Reply To Ticket](#reply-to-ticket)
+- [Reply to Ticket](#reply-to-ticket)
 - [Create Ticket Note](#create-ticket-note)
 - [Get All Conversations](#get-all-conversations)
 - [Get Contact](#get-contact)
@@ -144,7 +144,7 @@ Create ticket
 | Ticket ID | `ticket-id` | integer | The ID of the ticket |
 | Created At | `created-at` | string | Timestamp that denotes when the ticket/conversation was created. In UTC format. |
 
-### Reply To Ticket
+### Reply to Ticket
 
 Reply to a ticket thread.
 

--- a/application/whatsapp/v0/README.mdx
+++ b/application/whatsapp/v0/README.mdx
@@ -15,7 +15,7 @@ It can carry out the following tasks:
 - [Send Media Message](#send-media-message)
 - [Send Location Message](#send-location-message)
 - [Send Contact Message](#send-contact-message)
-- [Send Interactive Call To Action Url Button Message](#send-interactive-call-to-action-url-button-message)
+- [Send Interactive Call to Action Url Button Message](#send-interactive-call-to-action-url-button-message)
 
 ## Release Stage
 
@@ -241,7 +241,7 @@ Send contact message. Note: Message can only be sent when the 24-hour customer s
 | Recipient WhatsApp ID | `recipient-wa-id` | string | The WhatsApp ID of the recipient. Most likely the same with their phone number. |
 | Message ID | `message-id` | string | The ID of the message |
 
-### Send Interactive Call To Action Url Button Message
+### Send Interactive Call to Action Url Button Message
 
 Send interactive Call-To-Action URL button message. Note: Message can only be sent when the 24-hour customer service window is open. For more information: https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages#customer-service-windows 
 

--- a/data/instillartifact/v0/README.mdx
+++ b/data/instillartifact/v0/README.mdx
@@ -11,7 +11,7 @@ It can carry out the following tasks:
 - [Upload Files](#upload-files)
 - [Get Files Metadata](#get-files-metadata)
 - [Get Chunks Metadata](#get-chunks-metadata)
-- [Get File In Markdown](#get-file-in-markdown)
+- [Get File in Markdown](#get-file-in-markdown)
 - [Match File Status](#match-file-status)
 - [Retrieve](#retrieve)
 - [Ask](#ask)To use Artifact Component, you will need to set up the OpenAI API key for self-hosted deployment of Instill Core.
@@ -224,7 +224,7 @@ get the metadata of the chunks from a file in the catalog
 | Token Count | `token-count` | integer | The token count of the chunk |
 </details>
 
-### Get File In Markdown
+### Get File in Markdown
 
 get the file content in markdown format
 

--- a/operator/document/v0/README.mdx
+++ b/operator/document/v0/README.mdx
@@ -7,9 +7,9 @@ description: "Learn about how to set up a VDP Document component https://github.
 
 The Document component is an operator component that allows users to manipulate Document files.
 It can carry out the following tasks:
-- [Convert To Markdown](#convert-to-markdown)
-- [Convert To Text](#convert-to-text)
-- [Convert To Images](#convert-to-images)
+- [Convert to Markdown](#convert-to-markdown)
+- [Convert to Text](#convert-to-text)
+- [Convert to Images](#convert-to-images)
 
 ## Release Stage
 
@@ -23,7 +23,7 @@ The component definition and tasks are defined in the [definition.json](https://
 
 ## Supported Tasks
 
-### Convert To Markdown
+### Convert to Markdown
 
 Convert document to text in Markdown format.
 
@@ -45,7 +45,7 @@ Convert document to text in Markdown format.
 | Images (optional) | `images` | array[string] | Images extracted from the document |
 | Error (optional) | `error` | string | Error message if any during the conversion process |
 
-### Convert To Text
+### Convert to Text
 
 Convert document to text.
 
@@ -67,7 +67,7 @@ Convert document to text.
 | MSecs | `msecs` | number | Time taken to convert the document |
 | Error | `error` | string | Error message if any during the conversion process |
 
-### Convert To Images
+### Convert to Images
 
 Convert PDF to images.
 

--- a/operator/image/v0/README.mdx
+++ b/operator/image/v0/README.mdx
@@ -10,7 +10,7 @@ It can carry out the following tasks:
 - [Draw Classification](#draw-classification)
 - [Draw Detection](#draw-detection)
 - [Draw Keypoint](#draw-keypoint)
-- [Draw Ocr](#draw-ocr)
+- [Draw OCR](#draw-ocr)
 - [Draw Instance Segmentation](#draw-instance-segmentation)
 - [Draw Semantic Segmentation](#draw-semantic-segmentation)
 
@@ -137,7 +137,7 @@ The detected bounding box in (left, top, width, height) format.
 | :--- | :--- | :--- | :--- |
 | Image | `image` | string | Output image |
 
-### Draw Ocr
+### Draw OCR
 
 Draw OCR result on the image.
 
@@ -149,7 +149,7 @@ Draw OCR result on the image.
 | Show Score | `showScore` | boolean | Show model confidence score on each instance |
 
 <details>
-<summary> Input Objects in Draw Ocr</summary>
+<summary> Input Objects in Draw OCR</summary>
 
 <h4 id="draw-ocr-objects">Objects</h4>
 

--- a/tools/compogen/pkg/gen/readme.go
+++ b/tools/compogen/pkg/gen/readme.go
@@ -294,7 +294,7 @@ func parseREADMETasks(availableTasks []string, tasks map[string]task) ([]readmeT
 		rt.parseOneOfsProperties(t.Input.Properties)
 
 		if rt.Title = t.Title; rt.Title == "" {
-			rt.Title = componentbase.TaskIDToTitle(at)
+			rt.Title = titleCaseWithArticles(componentbase.TaskIDToTitle(at))
 		}
 
 		readmeTasks[i] = rt
@@ -541,6 +541,12 @@ func enumValues(enum []string) string {
 	return result
 }
 
+// List of words to keep in uppercase
+var uppercaseWords = map[string]bool{
+	"ocr": true,
+	"url": true,
+}
+
 // List of words to keep in lowercase (articles, conjunctions, prepositions)
 var lowercaseWords = map[string]bool{
 	"a":    true,
@@ -573,7 +579,10 @@ func titleCaseWithArticles(s string) string {
 	// Apply title case to each word
 	for i, word := range words {
 		lowerWord := strings.ToLower(word)
-		if i != 0 && lowercaseWords[lowerWord] {
+		if uppercaseWords[lowerWord] {
+			// Keep the word uppercase if it's in the uppercaseWords list
+			words[i] = strings.ToUpper(word)
+		} else if i != 0 && lowercaseWords[lowerWord] {
 			// Keep the word lowercase if it's not the first word and is in the lowercaseWords list
 			words[i] = lowerWord
 		} else {


### PR DESCRIPTION
Because

- titles should take into account articles, conjunctions, prepositions, and special terms

This commit

- apply general title rules, e.g., `OCR`, `Image to Text`, `URL`
