### PR TITLE
feat(universalai): add instill credit function for universal ai component

### DIFF
--- a/ai/universalai/v0/main.go
+++ b/ai/universalai/v0/main.go
@@ -62,6 +62,7 @@ func Init(bc base.Component) *component {
 func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution, error) {
 	e := &execution{
 		ComponentExecution: x,
+		component:          c,
 	}
 
 	switch x.Task {

--- a/ai/universalai/v0/text_chat_task.go
+++ b/ai/universalai/v0/text_chat_task.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/instill-ai/component/ai"
-	openaiv1 "github.com/instill-ai/component/ai/openai/v1"
 	"github.com/instill-ai/component/base"
 	"github.com/instill-ai/component/internal/util/httpclient"
-	"google.golang.org/protobuf/types/known/structpb"
+
+	openaiv1 "github.com/instill-ai/component/ai/openai/v1"
 )
 
 func (e *execution) ExecuteTextChat(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
@@ -21,8 +23,7 @@ func (e *execution) ExecuteTextChat(input *structpb.Struct, job *base.Job, ctx c
 	x := e.ComponentExecution
 	vendor := ModelVendorMap[inputStruct.Data.Model]
 
-	c := e.component
-	resolvedSetup, resolved, err := c.resolveSetup(vendor, x.Setup)
+	resolvedSetup, resolved, err := e.component.resolveSetup(vendor, x.Setup)
 
 	if err != nil {
 		return nil, err

--- a/ai/universalai/v0/text_chat_task.go
+++ b/ai/universalai/v0/text_chat_task.go
@@ -21,6 +21,16 @@ func (e *execution) ExecuteTextChat(input *structpb.Struct, job *base.Job, ctx c
 	x := e.ComponentExecution
 	vendor := ModelVendorMap[inputStruct.Data.Model]
 
+	c := e.component
+	resolvedSetup, resolved, err := c.resolveSetup(vendor, x.Setup)
+
+	if err != nil {
+		return nil, err
+	}
+
+	x.Setup = resolvedSetup
+	e.usesInstillCredentials = resolved
+
 	client, err := newClient(x.GetSetup(), x.GetLogger(), vendor)
 
 	if err != nil {

--- a/base/execution_wrapper.go
+++ b/base/execution_wrapper.go
@@ -108,6 +108,14 @@ func (e *ExecutionWrapper) Execute(ctx context.Context, jobs []*Job) (err error)
 	for batchIdx, job := range wrappedJobs {
 		outputs[batchIdx] = job.Output.(*outputWriter).GetOutput()
 	}
+
+	// Universal AI component set usesInstillCredentials when it executes, which is different from other AI components.
+	h, err = newUH(e)
+
+	if err != nil {
+		return err
+	}
+
 	if err := h.Collect(ctx, inputs, outputs); err != nil {
 		return err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/instill-ai/component/ai/ollama/v0"
 	"github.com/instill-ai/component/ai/openai/v0"
 	"github.com/instill-ai/component/ai/stabilityai/v0"
+	"github.com/instill-ai/component/ai/universalai/v0"
 	"github.com/instill-ai/component/application/asana/v0"
 	"github.com/instill-ai/component/application/email/v0"
 	"github.com/instill-ai/component/application/freshdesk/v0"
@@ -123,11 +124,12 @@ func Init(
 			conn = conn.WithInstillCredentials(secrets[conn.GetDefinitionID()])
 			compStore.Import(conn)
 		}
-		// {
-		// 	conn := universalai.Init(baseComp)
-		// 	conn = conn.WithInstillCredentials(secrets[conn.GetDefinitionID()])
-		// 	compStore.Import(conn)
-		// }
+		{
+			conn := universalai.Init(baseComp)
+			// Please apply more keys when we add more vendors
+			conn = conn.WithInstillCredentials("openai", secrets["openai"])
+			compStore.Import(conn)
+		}
 		{
 			// Anthropic
 			conn := anthropic.Init(baseComp)


### PR DESCRIPTION
Because

- we will support universal ai to execute vendors' ai models

This commit

- import the vendors' key to component and execution 
