### PR TITLE
chore(elasticsearch): fix typo

### DIFF
--- a/data/elasticsearch/v0/README.mdx
+++ b/data/elasticsearch/v0/README.mdx
@@ -263,7 +263,7 @@ Create an index in Elasticsearch
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CREATE_INDEX` |
 | Index Name (required) | `index-name` | string | Name of the Elasticsearch index |
-| Mappings | `mappings` | object | Index mappings which starts with \{"mappings":\{"properties"\}\} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings. |
+| Mappings | `mappings` | object | Index mappings which starts with \{"mappings":\{"properties"\}\} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html) for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings. |
 </div>
 
 

--- a/data/elasticsearch/v0/config/tasks.json
+++ b/data/elasticsearch/v0/config/tasks.json
@@ -881,7 +881,7 @@
           "type": "string"
         },
         "mappings": {
-          "description": "Index mappings which starts with {\"mappings\":{\"properties\"}} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings.",
+          "description": "Index mappings which starts with {\"mappings\":{\"properties\"}} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html) for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings.",
           "instillAcceptFormats": [
             "semi-structured/*",
             "object"


### PR DESCRIPTION
Because

- there is a typo

This commit

- fix typo
