### PR TITLE
feat(document): repair pdf with libreoffic

### DIFF
--- a/operator/document/v0/convert_to_images.go
+++ b/operator/document/v0/convert_to_images.go
@@ -45,8 +45,18 @@ func ConvertDocumentToImage(inputStruct *ConvertDocumentToImagesInput) (*Convert
 		base64PDF = strings.Split(inputStruct.Document, ",")[1]
 	}
 
+	var base64PDFWithoutMime string
+	if RequiredToRepair(base64PDF) {
+		base64PDFWithoutMime, err = RepairPDF(base64PDF)
+		if err != nil {
+			return nil, fmt.Errorf("failed to repair PDF: %w", err)
+		}
+	} else {
+		base64PDFWithoutMime = base.TrimBase64Mime(base64PDF)
+	}
+
 	paramsJSON := map[string]interface{}{
-		"PDF":      base.TrimBase64Mime(base64PDF),
+		"PDF":      base64PDFWithoutMime,
 		"filename": inputStruct.Filename,
 	}
 

--- a/operator/document/v0/execution/pdf_checker.py
+++ b/operator/document/v0/execution/pdf_checker.py
@@ -3,7 +3,9 @@ import json
 import base64
 import sys
 
-# TODO: Deal with the import error when running the code in the docker container
+# TODO chuang8511:
+# Deal with the import error when running the code in the docker container.
+# Now, we combine all python code into one file to avoid the import error.
 # from pdf_to_markdown import PDFTransformer
 
 if __name__ == "__main__":

--- a/operator/document/v0/execution/pdf_checker.py
+++ b/operator/document/v0/execution/pdf_checker.py
@@ -1,0 +1,21 @@
+from io import BytesIO
+import json
+import base64
+import sys
+
+# TODO: Deal with the import error when running the code in the docker container
+# from pdf_to_markdown import PDFTransformer
+
+if __name__ == "__main__":
+    json_str   = sys.stdin.buffer.read().decode('utf-8')
+    params     = json.loads(json_str)
+    pdf_string = params["PDF"]
+
+    decoded_bytes = base64.b64decode(pdf_string)
+    pdf_file_obj = BytesIO(decoded_bytes)
+    pdf = PDFTransformer(x=pdf_file_obj)
+    pages = pdf.raw_pages
+    output = {
+        "required": len(pages) == 0,
+    }
+    print(json.dumps(output))

--- a/operator/document/v0/execution/task_convert_to_images.py
+++ b/operator/document/v0/execution/task_convert_to_images.py
@@ -3,7 +3,9 @@ import json
 import base64
 import sys
 
-# TODO: Deal with the import error when running the code in the docker container
+# TODO chuang8511:
+# Deal with the import error when running the code in the docker container.
+# Now, we combine all python code into one file to avoid the import error.
 # from pdf_to_markdown import PDFTransformer
 # from pdf_to_markdown import PageImageProcessor
 

--- a/operator/document/v0/execution/task_convert_to_markdown.py
+++ b/operator/document/v0/execution/task_convert_to_markdown.py
@@ -3,7 +3,9 @@ import json
 import base64
 import sys
 
-# TODO: Deal with the import error when running the code in the docker container
+# TODO chuang8511:
+# Deal with the import error when running the code in the docker container.
+# Now, we combine all python code into one file to avoid the import error.
 # from pdf_to_markdown import PDFTransformer
 
 

--- a/operator/document/v0/helper.go
+++ b/operator/document/v0/helper.go
@@ -1,0 +1,43 @@
+package document
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/instill-ai/component/base"
+	"github.com/instill-ai/component/internal/util"
+)
+
+func RequiredToRepair(pdfBase64 string) bool {
+
+	paramsJSON := map[string]interface{}{
+		"PDF": base.TrimBase64Mime(pdfBase64),
+	}
+
+	pythonCode := pdfTransformer + pdfChecker
+
+	outputBytes, err := util.ExecutePythonCode(pythonCode, paramsJSON)
+
+	if err != nil {
+		// It shouldn't block the original process.
+		log.Println("failed to run python script: %w", err)
+		return false
+	}
+
+	var output struct {
+		Repair bool `json:"required"`
+	}
+
+	err = json.Unmarshal(outputBytes, &output)
+
+	if err != nil {
+		// It shouldn't block the original process.
+		log.Println("failed to unmarshal output: %w", err)
+	}
+
+	return output.Repair
+}
+
+func RepairPDF(pdfBase64 string) (string, error) {
+	return ConvertToPDF(pdfBase64, "pdf")
+}

--- a/operator/document/v0/main.go
+++ b/operator/document/v0/main.go
@@ -36,6 +36,9 @@ var (
 	//go:embed execution/task_convert_to_images.py
 	taskConvertToImagesExecution string
 
+	//go:embed execution/pdf_checker.py
+	pdfChecker string
+
 	once sync.Once
 	comp *component
 )

--- a/operator/document/v0/markdown_transformer.go
+++ b/operator/document/v0/markdown_transformer.go
@@ -275,7 +275,15 @@ func ConvertToPDF(base64Encoded, fileExtension string) (string, error) {
 	base64PDF, err := encodeFileToBase64(tempPDFName)
 
 	if err != nil {
-		return "", fmt.Errorf("failed to encode file to base64: %w", err)
+		// In the different containers, we have the different versions of LibreOffice, which means the behavior of LibreOffice may be different.
+		// So, we need to handle the case when the generated PDF is not in the temp directory.
+		if fileExtension == "pdf" {
+			base64PDF, err := encodeFileToBase64(inputFileName)
+			if err != nil {
+				return "", fmt.Errorf("failed to encode file to base64: %w", err)
+			}
+			return base64PDF, nil
+		}
 	}
 	return base64PDF, nil
 }

--- a/operator/document/v0/pdf_to_markdown/pdf_transformer.py
+++ b/operator/document/v0/pdf_to_markdown/pdf_transformer.py
@@ -5,7 +5,9 @@ from collections import Counter
 import pdfplumber
 from pdfplumber.page import Page
 
-# TODO: Deal with the import error when running the code in the docker container
+# TODO chuang8511:
+# Deal with the import error when running the code in the docker container.
+# Now, we combine all python code into one file to avoid the import error.
 # from page_image_processor import PageImageProcessor
 
 

--- a/operator/document/v0/pdf_to_markdown_converter.go
+++ b/operator/document/v0/pdf_to_markdown_converter.go
@@ -19,8 +19,19 @@ type converterOutput struct {
 
 func convertPDFToMarkdownWithPDFPlumber(base64Text string, displayImageTag bool, displayAllPage bool) (converterOutput, error) {
 
+	var pdfBase64 string
+	var err error
+	if RequiredToRepair(base64Text) {
+		pdfBase64, err = RepairPDF(base64Text)
+		if err != nil {
+			return converterOutput{}, fmt.Errorf("failed to repair PDF: %w", err)
+		}
+	} else {
+		pdfBase64 = base.TrimBase64Mime(base64Text)
+	}
+
 	paramsJSON, err := json.Marshal(map[string]interface{}{
-		"PDF":                    base.TrimBase64Mime(base64Text),
+		"PDF":                    pdfBase64,
 		"display-image-tag":      displayImageTag,
 		"display-all-page-image": displayAllPage,
 	})


### PR DESCRIPTION
Because

- The file could be malformed

This commit

- repair pdf with libreoffice without using function in pdfplumber because of licence issue
